### PR TITLE
Convert RsAsyncFunction from `fn` to `Fn` (function pointer to trait object)

### DIFF
--- a/src/inner_runtime.rs
+++ b/src/inner_runtime.rs
@@ -13,10 +13,9 @@ use std::{collections::HashMap, pin::Pin, rc::Rc, time::Duration};
 pub type RsFunction = fn(&FunctionArguments, &mut OpState) -> Result<serde_json::Value, Error>;
 
 /// Callback type for async rust callback functions
-pub type RsAsyncFunction =
-    fn(
-        Vec<serde_json::Value>,
-    ) -> Pin<Box<dyn std::future::Future<Output = Result<serde_json::Value, Error>>>>;
+pub type RsAsyncFunction = Box<dyn Fn(
+    Vec<serde_json::Value>,
+) -> Pin<Box<dyn std::future::Future<Output=Result<serde_json::Value, Error>>>>>;
 
 /// Type required to pass arguments to JsFunctions
 pub type FunctionArguments = [serde_json::Value];


### PR DESCRIPTION
This helps passing or sharing state to function of things that uses this, e.g., register_async_function. Have to be Box or else there will be Size issues.

@rscarson hopefully this doesn't break any tests - or anything else 😅