### PR TITLE
Fix build due to missing dependency feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ deno_webstorage = {version = "0.152.0", optional = true}
 deno_io = {version = "0.67.0", optional = true}
 rustyline = {version = "=14.0.0", optional = true}
 winapi = {version = "=0.3.9", optional = true, features = ["commapi", "knownfolders", "mswsock", "objbase", "psapi", "shlobj", "tlhelp32", "winbase", "winerror", "winuser", "winsock2", "processenv", "wincon", "wincontypes", "consoleapi"]}
-nix = {version = "=0.29.0", optional = true}
+nix = {version = "=0.29.0", optional = true, features = ["term"]}
 libc = {version = "0.2.155", optional = true}
 once_cell = {version = "1.19.0", optional = true}
 


### PR DESCRIPTION
```
 Documenting rustyscript v0.5.0 (https://github.com/rscarson/rustyscript?rev=126527a595bb532c1c2a68c2389d346e64efaec3#126527a5)
error[E0432]: unresolved import `nix::sys::termios`
   --> /Users/user/.cargo/git/checkouts/rustyscript-e3d48f33fc95c50c/126527a/src/ext/io/tty_unix.rs:18:5
    |
18  | use nix::sys::termios;
    |     ^^^^^^^^^^^^^^^^^ no `termios` in `sys`
    |
```