### PR TITLE
Custom import logic via a new ImportProvider trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ web = ["console", "url", "crypto", "deno_web", "deno_tls", "deno_fetch", "url_im
 # Features for the module loader
 fs_import = []
 url_import = ["reqwest"]
+nonstandard_import_urls = []
 
 # Enables the use of the SnapshotBuilder
 snapshot_builder = []

--- a/examples/custom_import_schemes.rs
+++ b/examples/custom_import_schemes.rs
@@ -36,7 +36,7 @@ impl ImportProvider for CustomImporter {
 
 fn main() -> Result<(), anyhow::Error> {
     let options = RuntimeOptions {
-        import_provider: Some(Box::new(CustomImporter::new())),
+        import_provider: Box::new(CustomImporter::new()),
         ..Default::default()
     };
     let mut runtime = Runtime::new(options)?;

--- a/examples/custom_import_schemes.rs
+++ b/examples/custom_import_schemes.rs
@@ -1,0 +1,50 @@
+use deno_core::anyhow;
+use rustyscript::{DefaultImporter, ImportProvider, Module, Runtime, RuntimeOptions};
+
+struct CustomImporter {
+    fallback_importer: DefaultImporter,
+}
+impl CustomImporter {
+    pub fn new() -> Self {
+        Self {
+            fallback_importer: DefaultImporter,
+        }
+    }
+}
+impl ImportProvider for CustomImporter {
+    fn import(
+        &self,
+        specifier: deno_core::ModuleSpecifier,
+    ) -> Result<String, anyhow::Error> {
+        // Define custom import behavior, depending on the specifier
+        match specifier.scheme() {
+            // Import from schemes that aren't `file` or `https`
+            "example" => {
+                Ok("
+                    export const test = 'Only those who master the art of the custom import scheme can print this string...'; 
+                ".to_string())
+            }
+            // Fall back to the default import behavior (or the behavior of another import provider)
+            _ => self.fallback_importer.import(specifier),
+        }
+    }
+}
+
+fn main() -> Result<(), anyhow::Error> {
+    let options = RuntimeOptions {
+        import_provider: Some(Box::new(CustomImporter::new())),
+        ..Default::default()
+    };
+    let mut runtime = Runtime::new(options)?;
+    let module = Module::new(
+        "example.js",
+        "
+        import { test } from 'example://any-specifier';
+        console.log(test);
+        "
+    );
+    
+    runtime.load_module(&module)?;
+
+    Ok(())    
+}

--- a/src/inner_runtime.rs
+++ b/src/inner_runtime.rs
@@ -5,7 +5,7 @@ use crate::{
     module_loader::RustyLoader,
     traits::{ToDefinedValue, ToModuleSpecifier, ToV8String},
     transpiler::{self, transpile_extension},
-    Error, ImportProvider, Module, ModuleHandle,
+    DefaultImporter, Error, ImportProvider, Module, ModuleHandle,
 };
 use deno_core::{serde_json, v8, JsRuntime, PollEventLoopOptions, RuntimeOptions};
 use std::{collections::HashMap, pin::Pin, rc::Rc, time::Duration};
@@ -54,7 +54,7 @@ pub struct InnerRuntimeOptions {
     pub module_cache: Option<Box<dyn ModuleCacheProvider>>,
 
     /// Optional import provider for the module loader
-    pub import_provider: Option<Box<dyn ImportProvider>>,
+    pub import_provider: Box<dyn ImportProvider>,
 
     /// Optional snapshot to load into the runtime
     /// This will reduce load times, but requires the same extensions to be loaded
@@ -70,7 +70,7 @@ impl Default for InnerRuntimeOptions {
             default_entrypoint: Default::default(),
             timeout: Duration::MAX,
             module_cache: None,
-            import_provider: None,
+            import_provider: Box::new(DefaultImporter),
             startup_snapshot: None,
 
             extension_options: Default::default(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,6 +240,7 @@ pub use js_function::JsFunction;
 pub use module::{Module, StaticModule};
 pub use module_handle::ModuleHandle;
 pub use module_wrapper::ModuleWrapper;
+pub use module_loader::{ImportProvider, DefaultImporter};
 pub use runtime::{Runtime, RuntimeOptions, Undefined};
 pub use utilities::{evaluate, import, resolve_path, validate};
 

--- a/src/module_loader.rs
+++ b/src/module_loader.rs
@@ -207,14 +207,11 @@ impl ModuleLoader for RustyLoader {
 impl RustyLoader {
     pub fn new(
         cache_provider: Option<Box<dyn ModuleCacheProvider>>,
-        import_provider: Option<Box<dyn ImportProvider>>,
+        import_provider: Box<dyn ImportProvider>,
     ) -> Self {
         Self {
             inner: Rc::new(InnerRustyLoader::new(cache_provider)),
-            import_provider: Rc::new(match import_provider {
-                Some(p) => p,
-                None => Box::new(DefaultImporter),
-            }),
+            import_provider: Rc::new(import_provider),
         }
     }
 
@@ -273,7 +270,7 @@ mod test {
             .get(&specifier)
             .expect("Expected to get cached source");
 
-        let loader = RustyLoader::new(Some(Box::new(cache_provider)), None);
+        let loader = RustyLoader::new(Some(Box::new(cache_provider)), Box::new(DefaultImporter));
         let response = loader.load(
             &specifier,
             None,

--- a/src/module_loader.rs
+++ b/src/module_loader.rs
@@ -108,7 +108,7 @@ impl ImportProvider for DefaultImporter {
         match specifier.scheme() {
             #[cfg(not(feature = "url_import"))]
             "https" | "http" => async move {
-                Err(anyhow!("web imports are not allowed here: {specifier}"));
+                Err(anyhow!("web imports are not allowed here: {specifier}"))
             }
             .boxed_local(),
             #[cfg(feature = "url_import")]

--- a/src/module_loader.rs
+++ b/src/module_loader.rs
@@ -25,7 +25,6 @@ struct InnerRustyLoader {
     source_map_cache: Rc<RefCell<SourceMapCache>>,
 }
 
-#[allow(dead_code)]
 impl InnerRustyLoader {
     fn new(cache_provider: Option<Box<dyn ModuleCacheProvider>>) -> Self {
         Self {
@@ -93,7 +92,6 @@ impl InnerRustyLoader {
 }
 
 pub trait ImportProvider {
-    #[allow(async_fn_in_trait)]
     fn import(
         &self,
         specifier: ModuleSpecifier,


### PR DESCRIPTION
In #128 @rscarson suggested making RustyLoader a generic over ModuleLoader, but the types associated with ModuleLoader's methods cause issues when using the trait this way. To work around this, I've created an object-safe trait called ImportProvider which has a single method that returns a pinned boxed future result.

I moved the existing import scheme handling to the new DefaultImporter struct, which implements ImportProvider. While DefaultImporter doesn't have any struct members, there's nothing stopping users from adding members to their own ImportProvider which can refer to said members while importing.

There are now 3 new missing-documentation warnings. If this PR's code is adequate, I will attempt to fill these out in a similar style to the rest of the project's doc comments.