### PR TITLE
WIP: `AsyncRuntime` and `AsyncWorker`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["web-programming", "network-programming", "api-bindings", "compile
 readme = "readme.md"
 
 [features]
-default = ["worker", "console", "url", "crypto"]
+default = ["console", "url", "crypto"]
 no_extensions = []
 all = ["web", "io"]
 
@@ -31,12 +31,13 @@ url_import = ["reqwest"]
 # Enables the use of the SnapshotBuilder
 snapshot_builder = []
 
-# Enables the threaded worker API
-worker = []
-
 sync = ["tokio/default"]
-async = []
-async-tokio = ["async", "tokio/time"]
+async = ["tokio/time"]
+
+# Enables the threaded worker API
+worker = ["dashmap"]
+sync-worker = ["worker", "sync"]
+async-worker = ["worker", "async", "tokio/default"]
 
 [dev-dependencies]
 version-sync = "0.9.5"
@@ -72,6 +73,11 @@ winapi = { version = "=0.3.9", optional = true, features = ["commapi", "knownfol
 nix = { version = "=0.29.0", optional = true, features = ["term"] }
 libc = { version = "0.2.155", optional = true }
 once_cell = { version = "1.19.0", optional = true }
+
+
+async-trait = "0.1.80"
+dashmap = { version =  "5.5.3", optional = true }
+log = "0.4.21"
 
 [[example]]
 name = "custom_threaded_worker"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,39 +34,44 @@ snapshot_builder = []
 # Enables the threaded worker API
 worker = []
 
+sync = ["tokio/default"]
+async = []
+async-tokio = ["async", "tokio/time"]
+
 [dev-dependencies]
 version-sync = "0.9.5"
 criterion = "0.5.1"
 
 [dependencies]
 deno_core = "0.290.0"
-deno_ast = { version = "0.39.2", features = ["transpiling"]}
+deno_ast = { version = "0.39.2", features = ["transpiling"] }
 thiserror = "1.0.61"
 serde = "1.0.203"
-tokio = "1.38.0"
+
+tokio = { version = "1.38.0", optional = true, default-features = false }
 
 # For URL imports
 # Pinned for now due to upstream issues
 reqwest = { version = "=0.12.4", optional = true, default-features = false, features = ["blocking", "rustls-tls"] }
 
 # Extension features
-deno_url = {version = "0.157.0", optional = true}
-deno_webidl = {version = "0.157.0", optional = true}
-deno_console = {version = "0.157.0", optional = true}
-deno_crypto = {version = "0.171.0", optional = true}
-deno_fetch = {version = "0.181.0", optional = true}
-deno_web = {version = "0.188.0", optional = true}
-deno_tls = {version = "0.144.0", optional = true}
-deno_net = {version = "0.149.0", optional = true}
-deno_webstorage = {version = "0.152.0", optional = true}
+deno_url = { version = "0.157.0", optional = true }
+deno_webidl = { version = "0.157.0", optional = true }
+deno_console = { version = "0.157.0", optional = true }
+deno_crypto = { version = "0.171.0", optional = true }
+deno_fetch = { version = "0.181.0", optional = true }
+deno_web = { version = "0.188.0", optional = true }
+deno_tls = { version = "0.144.0", optional = true }
+deno_net = { version = "0.149.0", optional = true }
+deno_webstorage = { version = "0.152.0", optional = true }
 
 # io feature deps
-deno_io = {version = "0.67.0", optional = true}
-rustyline = {version = "=14.0.0", optional = true}
-winapi = {version = "=0.3.9", optional = true, features = ["commapi", "knownfolders", "mswsock", "objbase", "psapi", "shlobj", "tlhelp32", "winbase", "winerror", "winuser", "winsock2", "processenv", "wincon", "wincontypes", "consoleapi"]}
-nix = {version = "=0.29.0", optional = true}
-libc = {version = "0.2.155", optional = true}
-once_cell = {version = "1.19.0", optional = true}
+deno_io = { version = "0.67.0", optional = true }
+rustyline = { version = "=14.0.0", optional = true }
+winapi = { version = "=0.3.9", optional = true, features = ["commapi", "knownfolders", "mswsock", "objbase", "psapi", "shlobj", "tlhelp32", "winbase", "winerror", "winuser", "winsock2", "processenv", "wincon", "wincontypes", "consoleapi"] }
+nix = { version = "=0.29.0", optional = true, features = ["term"] }
+libc = { version = "0.2.155", optional = true }
+once_cell = { version = "1.19.0", optional = true }
 
 [[example]]
 name = "custom_threaded_worker"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,9 +74,8 @@ nix = { version = "=0.29.0", optional = true, features = ["term"] }
 libc = { version = "0.2.155", optional = true }
 once_cell = { version = "1.19.0", optional = true }
 
-
 async-trait = "0.1.80"
-dashmap = { version =  "5.5.3", optional = true }
+dashmap = { version = "5.5.3", optional = true }
 log = "0.4.21"
 
 [[example]]

--- a/src/async_runtime.rs
+++ b/src/async_runtime.rs
@@ -1,0 +1,284 @@
+use crate::{
+    inner_runtime::{InnerRuntime, InnerRuntimeOptions, RsAsyncFunction, RsFunction, AsyncInnerRuntime},
+    Error, FunctionArguments, JsFunction, Module, ModuleHandle,
+};
+use deno_core::serde_json;
+
+/// Represents the set of options accepted by the runtime constructor
+pub type AsyncRuntimeOptions = InnerRuntimeOptions;
+pub type RuntimeOptions = AsyncRuntimeOptions;
+
+/// For functions returning nothing
+pub type Undefined = serde_json::Value;
+
+/// Represents a configured runtime ready to run modules
+pub struct AsyncRuntime(InnerRuntime);
+
+impl AsyncRuntime {
+    /// The lack of any arguments - used to simplify calling functions
+    /// Prevents you from needing to specify the type using ::<serde_json::Value>
+    pub const EMPTY_ARGS: &'static FunctionArguments = &[];
+
+    /// Creates a new instance of the runtime with the provided options.
+    ///
+    /// # Arguments
+    /// * `options` - A `RuntimeOptions` struct that specifies the configuration options for the runtime.
+    ///
+    /// # Returns
+    /// A `Result` containing either the initialized runtime instance on success (`Ok`) or an error on failure (`Err`).
+    ///
+    pub fn new(options: RuntimeOptions) -> Result<Self, Error> {
+        Ok(Self(InnerRuntime::new(options)?))
+    }
+
+    /// Access the underlying deno runtime instance directly
+    pub fn deno_runtime(&mut self) -> &mut deno_core::JsRuntime {
+        self.0.deno_runtime()
+    }
+
+    /// Access the options used to create this runtime
+    pub fn options(&self) -> &RuntimeOptions {
+        &self.0.options
+    }
+
+    /// Encode an argument as a json value for use as a function argument
+    pub fn arg<A>(value: A) -> Result<serde_json::Value, Error>
+    where
+        A: serde::Serialize,
+    {
+        Ok(serde_json::to_value(value)?)
+    }
+
+    /// Encode a primitive as a json value for use as a function argument
+    /// Only for types with `Into<Value>`. For other types, use `Runtime::arg`
+    pub fn into_arg<A>(value: A) -> serde_json::Value
+    where
+        serde_json::Value: From<A>,
+    {
+        serde_json::Value::from(value)
+    }
+
+    /// Remove and return a value from the state, if one exists
+    pub fn take<T>(&mut self) -> Option<T>
+    where
+        T: 'static,
+    {
+        self.0.take()
+    }
+
+    /// Add a value to the state
+    /// Only one value of each type is stored - additional calls to put overwrite the
+    /// old value
+    /// ```rust
+    /// use rustyscript::{ Runtime };
+    ///
+    /// # fn main() -> Result<(), rustyscript::Error> {
+    /// let mut runtime = Runtime::new(Default::default())?;
+    /// runtime.put("test".to_string())?;
+    /// let value: String = runtime.take().unwrap();
+    /// assert_eq!(value, "test");
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn put<T>(&mut self, value: T) -> Result<(), Error>
+    where
+        T: 'static,
+    {
+        self.0.put(value)
+    }
+
+    /// Register a rust function to be callable from JS
+    pub fn register_function<F>(&mut self, name: &str, callback: F) -> Result<(), Error>
+    where
+        F: RsFunction,
+    {
+        self.0.register_function(name, callback)
+    }
+
+    /// Register a non-blocking rust function to be callable from JS
+    pub fn register_async_function<F>(&mut self, name: &str, callback: F) -> Result<(), Error>
+    where
+        F: RsAsyncFunction,
+    {
+        self.0.register_async_function(name, callback)
+    }
+
+    /// Evaluate a piece of non-ECMAScript-module JavaScript code
+    /// The expression is evaluated in the global context, so changes persist
+    ///
+    /// # Arguments
+    /// * `expr` - A string representing the JavaScript expression to evaluate
+    ///
+    /// # Returns
+    /// A `Result` containing the deserialized result of the expression (`T`)
+    /// or an error (`Error`) if the expression cannot be evaluated or if the
+    /// result cannot be deserialized.
+    pub fn eval<T>(&mut self, expr: &str) -> Result<T, Error>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        self.0.eval(expr)
+    }
+
+    /// Calls a stored javascript function and deserializes its return value.
+    ///
+    /// # Arguments
+    /// * `module_context` - Optional handle to a module providing global context for the function
+    /// * `function` - A The function object
+    /// * `args` - The arguments to pass to the function
+    ///
+    /// # Returns
+    /// A `Result` containing the deserialized result of the function call (`T`)
+    /// or an error (`Error`) if the function cannot be found, if there are issues with
+    /// calling the function, or if the result cannot be deserialized.
+    pub async fn call_stored_function<T>(
+        &mut self,
+        module_context: Option<&ModuleHandle>,
+        function: &JsFunction<'_>,
+        args: &FunctionArguments,
+    ) -> Result<T, Error>
+    where
+        T: deno_core::serde::de::DeserializeOwned,
+    {
+        self.0.call_stored_function(module_context, function, args).await
+    }
+
+    /// Calls a javascript function within the Deno runtime by its name and deserializes its return value.
+    ///
+    /// # Arguments
+    /// * `module_context` - Optional handle to a module to search - if None, or if the search fails, the global context is used
+    /// * `name` - A string representing the name of the javascript function to call.
+    /// * `args` - The arguments to pass to the function
+    ///
+    /// # Returns
+    /// A `Result` containing the deserialized result of the function call (`T`)
+    /// or an error (`Error`) if the function cannot be found, if there are issues with
+    /// calling the function, or if the result cannot be deserialized.
+    pub async fn call_function<T>(
+        &mut self,
+        module_context: Option<&ModuleHandle>,
+        name: &str,
+        args: &FunctionArguments,
+    ) -> Result<T, Error>
+    where
+        T: deno_core::serde::de::DeserializeOwned,
+    {
+        self.0.call_function(module_context, name, args).await
+    }
+
+    /// Get a value from a runtime instance
+    ///
+    /// # Arguments
+    /// * `module_context` - Optional handle to a module to search - if None, or if the search fails, the global context is used
+    /// * `name` - A string representing the name of the value to find
+    ///
+    /// # Returns
+    /// A `Result` containing the deserialized result or an error (`Error`) if the
+    /// value cannot be found, if there are issues with, or if the result cannot be
+    ///  deserialized.
+    pub async fn get_value<T>(
+        &mut self,
+        module_context: Option<&ModuleHandle>,
+        name: &str,
+    ) -> Result<T, Error>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        self.0.get_value(module_context, name).await
+    }
+
+    /// Executes the given module, and returns a handle allowing you to extract values
+    /// And call functions
+    ///
+    /// # Arguments
+    /// * `module` - A `Module` object containing the module's filename and contents.
+    ///
+    /// # Returns
+    /// A `Result` containing a handle for the loaded module
+    /// or an error (`Error`) if there are issues with loading modules, executing the
+    /// module, or if the result cannot be deserialized.
+    pub async fn load_module(&mut self, module: &Module) -> Result<ModuleHandle, Error> {
+        self.0.load_modules(None, vec![module]).await
+    }
+
+    /// Executes the given module, and returns a handle allowing you to extract values
+    /// And call functions.
+    ///
+    /// This will load 'module' as the main module, and the others as side-modules.
+    /// Only one main module can be loaded per runtime
+    ///
+    /// # Arguments
+    /// * `module` - A `Module` object containing the module's filename and contents.
+    /// * `side_modules` - A set of additional modules to be loaded into memory for use
+    ///
+    /// # Returns
+    /// A `Result` containing a handle for the loaded module
+    /// or an error (`Error`) if there are issues with loading modules, executing the
+    /// module, or if the result cannot be deserialized.
+    pub async fn load_modules(
+        &mut self,
+        module: &Module,
+        side_modules: Vec<&Module>,
+    ) -> Result<ModuleHandle, Error> {
+        self.0.load_modules(Some(module), side_modules).await
+    }
+
+    /// Executes the entrypoint function of a module within the Deno runtime.
+    ///
+    /// # Arguments
+    /// * `module_context` - A handle returned by loading a module into the runtime
+    ///
+    /// # Returns
+    /// A `Result` containing the deserialized result of the entrypoint execution (`T`)
+    /// if successful, or an error (`Error`) if the entrypoint is missing, the execution fails,
+    /// or the result cannot be deserialized.
+    pub async fn call_entrypoint<T>(
+        &mut self,
+        module_context: &ModuleHandle,
+        args: &FunctionArguments,
+    ) -> Result<T, Error>
+    where
+        T: deno_core::serde::de::DeserializeOwned,
+    {
+        if let Some(entrypoint) = module_context.entrypoint() {
+            let value: serde_json::Value = self.0.call_function_by_ref(
+                Some(module_context),
+                entrypoint.clone(),
+                args,
+            ).await?;
+            Ok(serde_json::from_value(value)?)
+        } else {
+            Err(Error::MissingEntrypoint(module_context.module().clone()))
+        }
+    }
+
+    /// Loads a module into a new runtime, executes the entry function and returns the
+    /// result of the module's execution, deserialized into the specified Rust type (`T`).
+    ///
+    /// # Arguments
+    /// * `module` - A `Module` object containing the module's filename and contents.
+    /// * `side_modules` - A set of additional modules to be loaded into memory for use
+    /// * `runtime_options` - Options for the creation of the runtime
+    /// * `entrypoint_args` - Arguments to pass to the entrypoint function
+    ///
+    /// # Returns
+    /// A `Result` containing the deserialized result of the entrypoint execution (`T`)
+    /// if successful, or an error (`Error`) if the entrypoint is missing, the execution fails,
+    /// or the result cannot be deserialized.
+    pub async fn execute_module<T>(
+        module: &Module,
+        side_modules: Vec<&Module>,
+        runtime_options: RuntimeOptions,
+        entrypoint_args: &FunctionArguments,
+    ) -> Result<T, Error>
+    where
+        T: deno_core::serde::de::DeserializeOwned,
+    {
+        let mut runtime = Self::new(runtime_options)?;
+        let module = runtime.load_modules(module, side_modules).await?;
+        let value: T = runtime.call_entrypoint(&module, entrypoint_args).await?;
+        Ok(value)
+    }
+}
+
+// TODO: test

--- a/src/async_runtime.rs
+++ b/src/async_runtime.rs
@@ -158,14 +158,16 @@ impl AsyncRuntime {
     /// calling the function, or if the result cannot be deserialized.
     pub async fn call_function<T>(
         &mut self,
-        module_context: Option<&ModuleHandle>,
+        module_context: Option<ModuleHandle>,
         name: &str,
-        args: &FunctionArguments,
+        args: Box<FunctionArguments>,
     ) -> Result<T, Error>
     where
         T: deno_core::serde::de::DeserializeOwned,
     {
-        self.0.call_function(module_context, name, args).await
+        let module_context = module_context;
+        let module_context = module_context.as_ref().map(|m| m as &ModuleHandle);
+        self.0.call_function(module_context, name, &args).await
     }
 
     /// Get a value from a runtime instance
@@ -180,13 +182,15 @@ impl AsyncRuntime {
     ///  deserialized.
     pub async fn get_value<T>(
         &mut self,
-        module_context: Option<&ModuleHandle>,
+        module_context: Option<ModuleHandle>,
         name: &str,
     ) -> Result<T, Error>
     where
         T: serde::de::DeserializeOwned,
     {
-        self.0.get_value(module_context, name).await
+        let m = module_context;
+        let m = m.as_ref();
+        self.0.get_value(m, name).await
     }
 
     /// Executes the given module, and returns a handle allowing you to extract values

--- a/src/async_runtime.rs
+++ b/src/async_runtime.rs
@@ -21,6 +21,8 @@ impl AsyncRuntime {
 
     /// Creates a new instance of the runtime with the provided options.
     ///
+    /// The async runtime must run in a single threaded Tokio runtime
+    ///
     /// # Arguments
     /// * `options` - A `RuntimeOptions` struct that specifies the configuration options for the runtime.
     ///

--- a/src/inner_runtime.rs
+++ b/src/inner_runtime.rs
@@ -791,7 +791,7 @@ pub trait AsyncInnerRuntime {
     ) -> Result<v8::Global<v8::Value>, Error>;
 }
 
-#[cfg(feature = "async-tokio")]
+#[cfg(feature = "async")]
 use tokio::time::{timeout as tokio_timeout};
 
 #[cfg(feature = "async")]
@@ -808,7 +808,7 @@ impl AsyncInnerRuntime for InnerRuntime {
 
         let module_handle_stub = self.load_modules_stub(main_module, side_modules);
 
-        let module_handle_stub = if cfg!(feature = "async-tokio") {
+        let module_handle_stub = if cfg!(feature = "async") {
             tokio_timeout(timeout, module_handle_stub).await??
         } else {
             module_handle_stub.await?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,6 +217,8 @@ mod module_loader;
 mod module_wrapper;
 #[cfg(feature = "sync")]
 pub mod runtime;
+#[cfg(feature = "async")]
+pub mod async_runtime;
 mod traits;
 mod transpiler;
 mod utilities;
@@ -236,7 +238,11 @@ pub use ext::web::WebOptions;
 pub use ext::ExtensionOptions;
 
 #[cfg(feature = "sync")]
-pub use runtime::{Runtime, RuntimeOptions, Undefined};
+pub use runtime::{Runtime, RuntimeOptions};
+#[cfg(feature = "async")]
+pub use async_runtime::{AsyncRuntime, AsyncRuntimeOptions};
+
+pub type Undefined = serde_json::Value;
 
 // Expose some important stuff from us
 pub use error::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@
 //! runtime.call_entrypoint::<Undefined>(&module_handle, json_args!(2))?;
 //!
 //! // Functions don't need to be the entrypoint to be callable!
-//! let internal_value: i64 = runtime.call_function(&module_handle, "getValue", json_args!())?;
+//! let internal_value: i64 = runtime.call_function(Some(&module_handle), "getValue", json_args!())?;
 //! # Ok(())
 //! # }
 //! ```
@@ -201,6 +201,7 @@ mod v8_serializer;
 
 #[cfg(feature = "snapshot_builder")]
 mod snapshot_builder;
+
 #[cfg(feature = "snapshot_builder")]
 pub use snapshot_builder::SnapshotBuilder;
 
@@ -214,7 +215,8 @@ mod module;
 mod module_handle;
 mod module_loader;
 mod module_wrapper;
-mod runtime;
+#[cfg(feature = "sync")]
+pub mod runtime;
 mod traits;
 mod transpiler;
 mod utilities;
@@ -233,6 +235,9 @@ pub use deno_tls;
 pub use ext::web::WebOptions;
 pub use ext::ExtensionOptions;
 
+#[cfg(feature = "sync")]
+pub use runtime::{Runtime, RuntimeOptions, Undefined};
+
 // Expose some important stuff from us
 pub use error::Error;
 pub use inner_runtime::{FunctionArguments, RsAsyncFunction, RsFunction};
@@ -240,7 +245,6 @@ pub use js_function::JsFunction;
 pub use module::{Module, StaticModule};
 pub use module_handle::ModuleHandle;
 pub use module_wrapper::ModuleWrapper;
-pub use runtime::{Runtime, RuntimeOptions, Undefined};
 pub use utilities::{evaluate, import, resolve_path, validate};
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,7 +221,8 @@ pub mod runtime;
 pub mod async_runtime;
 mod traits;
 mod transpiler;
-mod utilities;
+
+pub mod utilities;
 
 #[cfg(feature = "worker")]
 pub mod worker;
@@ -237,10 +238,11 @@ pub use deno_tls;
 pub use ext::web::WebOptions;
 pub use ext::ExtensionOptions;
 
+pub use inner_runtime::{InnerRuntimeOptions as RuntimeOptions};
 #[cfg(feature = "sync")]
-pub use runtime::{Runtime, RuntimeOptions};
+pub use runtime::Runtime;
 #[cfg(feature = "async")]
-pub use async_runtime::{AsyncRuntime, AsyncRuntimeOptions};
+pub use async_runtime::AsyncRuntime;
 
 pub type Undefined = serde_json::Value;
 
@@ -250,8 +252,11 @@ pub use inner_runtime::{FunctionArguments, RsAsyncFunction, RsFunction};
 pub use js_function::JsFunction;
 pub use module::{Module, StaticModule};
 pub use module_handle::ModuleHandle;
+
+#[cfg(feature = "sync")]
 pub use module_wrapper::ModuleWrapper;
-pub use utilities::{evaluate, import, resolve_path, validate};
+#[cfg(feature = "sync")]
+pub use utilities::sync::{evaluate, import, resolve_path, validate};
 
 #[cfg(test)]
 mod test {

--- a/src/module_wrapper.rs
+++ b/src/module_wrapper.rs
@@ -1,13 +1,18 @@
 use deno_core::{serde_json, v8::GetPropertyNamesArgs};
 
-use crate::{Error, JsFunction, Module, ModuleHandle, Runtime, RuntimeOptions};
+use crate::{Error, JsFunction, Module, ModuleHandle};
+
+#[cfg(feature = "sync")]
+use crate::{Runtime, RuntimeOptions};
 
 /// A wrapper type representing a runtime instance loaded with a single module
+#[cfg(feature = "sync")]
 pub struct ModuleWrapper {
     module_context: ModuleHandle,
     runtime: Runtime,
 }
 
+#[cfg(feature = "sync")]
 impl ModuleWrapper {
     /// Creates a new `ModuleWrapper` from a given module and runtime options.
     ///
@@ -158,6 +163,7 @@ impl ModuleWrapper {
 }
 
 #[cfg(test)]
+#[cfg(feature = "sync")]
 mod test_runtime {
     use super::*;
     use crate::json_args;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,5 +1,5 @@
 use crate::{
-    inner_runtime::{InnerRuntime, InnerRuntimeOptions, RsAsyncFunction, RsFunction},
+    inner_runtime::{InnerRuntime, InnerRuntimeOptions, RsAsyncFunction, RsFunction, SyncInnerRuntime},
     Error, FunctionArguments, JsFunction, Module, ModuleHandle,
 };
 use deno_core::serde_json;
@@ -443,7 +443,7 @@ impl Runtime {
         T: deno_core::serde::de::DeserializeOwned,
     {
         if let Some(entrypoint) = module_context.entrypoint() {
-            let value: serde_json::Value = self.0.call_function_by_ref_async(
+            let value: serde_json::Value = self.0.call_function_by_ref(
                 Some(module_context),
                 entrypoint.clone(),
                 args,
@@ -513,7 +513,7 @@ mod test_runtime {
             extensions: vec![test_extension::init_ops_and_esm()],
             ..Default::default()
         })
-        .expect("Could not create runtime with extensions");
+            .expect("Could not create runtime with extensions");
     }
 
     #[test]
@@ -602,7 +602,7 @@ mod test_runtime {
             timeout: Duration::from_millis(50),
             ..Default::default()
         })
-        .expect("Could not create the runtime");
+            .expect("Could not create the runtime");
         let module = Module::new(
             "test.js",
             "
@@ -654,7 +654,7 @@ mod test_runtime {
             timeout: Duration::from_millis(50),
             ..Default::default()
         })
-        .expect("Could not create the runtime");
+            .expect("Could not create the runtime");
         let module = Module::new(
             "test.js",
             "
@@ -687,7 +687,7 @@ mod test_runtime {
             default_entrypoint: Some("load".to_string()),
             ..Default::default()
         })
-        .expect("Could not create the runtime");
+            .expect("Could not create the runtime");
         let module = Module::new(
             "test.js",
             "

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -14,10 +14,6 @@ pub type Undefined = serde_json::Value;
 pub struct Runtime(InnerRuntime);
 
 impl Runtime {
-    /// The lack of any arguments - used to simplify calling functions
-    /// Prevents you from needing to specify the type using ::<serde_json::Value>
-    pub const EMPTY_ARGS: &'static FunctionArguments = &[];
-
     /// Creates a new instance of the runtime with the provided options.
     ///
     /// # Arguments
@@ -98,7 +94,7 @@ impl Runtime {
     where
         A: serde::Serialize,
     {
-        Ok(serde_json::to_value(value)?)
+        crate::utilities::arg(value)
     }
 
     /// Encode a primitive as a json value for use as a function argument
@@ -130,7 +126,7 @@ impl Runtime {
     where
         serde_json::Value: From<A>,
     {
-        serde_json::Value::from(value)
+        crate::utilities::into_arg(value)
     }
 
     /// Remove and return a value from the state, if one exists

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -1,87 +1,154 @@
+use crate::{Error, FunctionArguments, serde_json};
 use crate::traits::ToModuleSpecifier;
-use crate::{Error, Module, ModuleWrapper, Runtime};
 
-/// Evaluate a piece of non-ECMAScript-module JavaScript code
-/// Effects on the global scope will not persist
-/// For a persistant variant, see [Runtime::eval]
-///
-/// # Arguments
-/// * `javascript` - A single javascript expression
-///
-/// # Returns
-/// A `Result` containing the deserialized result of the expression if successful,
-/// or an error if execution fails, or the result cannot be deserialized.
-///
-/// # Example
-///
-/// ```rust
-/// let result: i64 = rustyscript::evaluate("5 + 5").expect("The expression was invalid!");
-/// assert_eq!(10, result);
-/// ```
-pub fn evaluate<T>(javascript: &str) -> Result<T, Error>
+/// The lack of any arguments - used to simplify calling functions
+/// Prevents you from needing to specify the type using ::<serde_json::Value>
+pub const EMPTY_ARGS: &'static FunctionArguments = &[];
+
+pub fn arg<A>(value: A) -> Result<serde_json::Value, Error>
 where
-    T: deno_core::serde::de::DeserializeOwned,
+    A: serde::Serialize,
 {
-    let mut runtime = Runtime::new(Default::default())?;
-    runtime.eval(javascript)
+    Ok(serde_json::to_value(value)?)
 }
 
-/// Validates the syntax of some JS
-///
-/// # Arguments
-/// * `javascript` - A snippet of JS code
-///
-/// # Returns
-/// A `Result` containing a boolean determining the validity of the JS,
-/// or an error if something went wrong.
-///
-/// # Example
-///
-/// ```rust
-/// assert!(rustyscript::validate("5 + 5").expect("Something went wrong!"));
-/// ```
-pub fn validate(javascript: &str) -> Result<bool, Error> {
-    let module = Module::new("test.js", javascript);
-    let mut runtime = Runtime::new(Default::default())?;
-    match runtime.load_modules(&module, vec![]) {
-        Ok(_) => Ok(true),
-        Err(Error::Runtime(_)) => Ok(false),
-        Err(Error::JsError(_)) => Ok(false),
-        Err(e) => Err(e),
+pub fn into_arg<A>(value: A) -> serde_json::Value
+where
+    serde_json::Value: From<A>,
+{
+    serde_json::Value::from(value)
+}
+
+#[cfg(feature = "sync")]
+pub mod sync {
+    use crate::{Error, Module, ModuleWrapper, Runtime};
+    use crate::traits::ToModuleSpecifier;
+
+    /// Evaluate a piece of non-ECMAScript-module JavaScript code
+    /// Effects on the global scope will not persist
+    /// For a persistant variant, see [Runtime::eval]
+    ///
+    /// # Arguments
+    /// * `javascript` - A single javascript expression
+    ///
+    /// # Returns
+    /// A `Result` containing the deserialized result of the expression if successful,
+    /// or an error if execution fails, or the result cannot be deserialized.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let result: i64 = rustyscript::evaluate("5 + 5").expect("The expression was invalid!");
+    /// assert_eq!(10, result);
+    /// ```
+    pub fn evaluate<T>(javascript: &str) -> Result<T, Error>
+    where
+        T: deno_core::serde::de::DeserializeOwned,
+    {
+        let mut runtime = Runtime::new(Default::default())?;
+        runtime.eval(javascript)
     }
-}
 
-/// Imports a JS module into a new runtime
-///
-/// # Arguments
-/// * `path` - Path to the JS module to import
-///
-/// # Returns
-/// A `Result` containing a handle to the imported module,
-/// or an error if something went wrong.
-///
-/// # Example
-///
-/// ```no_run
-/// let mut module = rustyscript::import("js/my_module.js").expect("Something went wrong!");
-/// ```
-pub fn import(path: &str) -> Result<ModuleWrapper, Error> {
-    ModuleWrapper::new_from_file(path, Default::default())
-}
+    /// Validates the syntax of some JS
+    ///
+    /// # Arguments
+    /// * `javascript` - A snippet of JS code
+    ///
+    /// # Returns
+    /// A `Result` containing a boolean determining the validity of the JS,
+    /// or an error if something went wrong.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// assert!(rustyscript::validate("5 + 5").expect("Something went wrong!"));
+    /// ```
+    pub fn validate(javascript: &str) -> Result<bool, Error> {
+        let module = Module::new("test.js", javascript);
+        let mut runtime = Runtime::new(Default::default())?;
+        match runtime.load_modules(&module, vec![]) {
+            Ok(_) => Ok(true),
+            Err(Error::Runtime(_)) => Ok(false),
+            Err(Error::JsError(_)) => Ok(false),
+            Err(e) => Err(e),
+        }
+    }
 
-/// Resolve a path to absolute path
-///
-/// # Arguments
-/// * `path` - A path
-///
-/// # Example
-///
-/// ```rust
-/// let full_path = rustyscript::resolve_path("test.js").expect("Something went wrong!");
-/// assert!(full_path.ends_with("test.js"));
-/// ```
-pub fn resolve_path(path: &str) -> Result<String, Error> {
-    Ok(path.to_module_specifier()?.to_string())
+    /// Imports a JS module into a new runtime
+    ///
+    /// # Arguments
+    /// * `path` - Path to the JS module to import
+    ///
+    /// # Returns
+    /// A `Result` containing a handle to the imported module,
+    /// or an error if something went wrong.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// let mut module = rustyscript::import("js/my_module.js").expect("Something went wrong!");
+    /// ```
+    pub fn import(path: &str) -> Result<ModuleWrapper, Error> {
+        ModuleWrapper::new_from_file(path, Default::default())
+    }
+
+    /// Resolve a path to absolute path
+    ///
+    /// # Arguments
+    /// * `path` - A path
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let full_path = rustyscript::resolve_path("test.js").expect("Something went wrong!");
+    /// assert!(full_path.ends_with("test.js"));
+    /// ```
+    pub fn resolve_path(path: &str) -> Result<String, Error> {
+        Ok(path.to_module_specifier()?.to_string())
+    }
+
+    #[cfg(test)]
+    mod test_runtime {
+        use super::*;
+        use deno_core::{futures::FutureExt, serde_json};
+        use crate::{async_callback, evaluate, resolve_path, sync_callback, validate};
+
+        #[test]
+        fn test_callback() {
+            let add = sync_callback!(|a: i64, b: i64| { Ok::<i64, Error>(a + b) });
+
+            let add2 = async_callback!(|a: i64, b: i64| { async move { Ok::<i64, Error>(a + b) } });
+
+            let args = vec![
+                serde_json::Value::Number(5.into()),
+                serde_json::Value::Number(5.into()),
+            ];
+            let result = add(&args).unwrap();
+            assert_eq!(serde_json::Value::Number(10.into()), result);
+
+            let result = add2(args).now_or_never().unwrap().unwrap();
+            assert_eq!(serde_json::Value::Number(10.into()), result);
+        }
+
+        #[test]
+        fn test_evaluate() {
+            assert_eq!(5, evaluate::<i64>("3 + 2").expect("invalid expression"));
+            evaluate::<i64>("a5; 3 + 2").expect_err("Expected an error");
+        }
+
+        #[test]
+        fn test_validate() {
+            assert_eq!(true, validate("3 + 2").expect("invalid expression"));
+            assert_eq!(false, validate("5;+-").expect("invalid expression"));
+        }
+
+        #[test]
+        fn test_resolve_path() {
+            assert!(resolve_path("test.js")
+                .expect("invalid path")
+                .ends_with("test.js"));
+        }
+    }
 }
 
 #[macro_use]
@@ -114,12 +181,25 @@ mod runtime_macros {
     macro_rules! json_args {
         ($($arg:expr),+) => {
             &[
-                $($crate::Runtime::into_arg($arg)),+
+                $($crate::utilities::into_arg($arg)),+
             ]
         };
 
         () => {
-            $crate::Runtime::EMPTY_ARGS
+            $crate::utilities::EMPTY_ARGS
+        };
+    }
+
+    #[macro_export]
+    macro_rules! json_args_vec {
+        ($($arg:expr),+) => {
+            (&[
+                $($crate::utilities::into_arg($arg)),+
+            ]).to_vec()
+        };
+
+        () => {
+            vec![]
         };
     }
 
@@ -184,44 +264,4 @@ mod runtime_macros {
     }
 }
 
-#[cfg(test)]
-mod test_runtime {
-    use super::*;
-    use deno_core::{futures::FutureExt, serde_json};
 
-    #[test]
-    fn test_callback() {
-        let add = sync_callback!(|a: i64, b: i64| { Ok::<i64, Error>(a + b) });
-
-        let add2 = async_callback!(|a: i64, b: i64| { async move { Ok::<i64, Error>(a + b) } });
-
-        let args = vec![
-            serde_json::Value::Number(5.into()),
-            serde_json::Value::Number(5.into()),
-        ];
-        let result = add(&args).unwrap();
-        assert_eq!(serde_json::Value::Number(10.into()), result);
-
-        let result = add2(args).now_or_never().unwrap().unwrap();
-        assert_eq!(serde_json::Value::Number(10.into()), result);
-    }
-
-    #[test]
-    fn test_evaluate() {
-        assert_eq!(5, evaluate::<i64>("3 + 2").expect("invalid expression"));
-        evaluate::<i64>("a5; 3 + 2").expect_err("Expected an error");
-    }
-
-    #[test]
-    fn test_validate() {
-        assert_eq!(true, validate("3 + 2").expect("invalid expression"));
-        assert_eq!(false, validate("5;+-").expect("invalid expression"));
-    }
-
-    #[test]
-    fn test_resolve_path() {
-        assert!(resolve_path("test.js")
-            .expect("invalid path")
-            .ends_with("test.js"));
-    }
-}

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,29 +1,6 @@
-//! Provides a worker thread that can be used to run javascript code in a separate thread through a channel pair
-//! It also provides a default worker implementation that can be used without any additional setup:
-//! ```rust
-//! use rustyscript::{Error, worker::{Worker, DefaultWorker, DefaultWorkerOptions}};
-//! use std::time::Duration;
-//!
-//! fn main() -> Result<(), Error> {
-//!     let worker = DefaultWorker::new(DefaultWorkerOptions {
-//!         default_entrypoint: None,
-//!         timeout: Duration::from_secs(5),
-//!     })?;
-//!
-//!     worker.register_function("add".to_string(), |args, _state| {
-//!         let a = args[0].as_i64().unwrap();
-//!         let b = args[1].as_i64().unwrap();
-//!         let result = a + b;
-//!         Ok(result.into())
-//!     })?;
-//!     let result: i32 = worker.eval("add(5, 5)".to_string())?;
-//!     assert_eq!(result, 10);
-//!     Ok(())
-//! }
-
+use std::sync::mpsc::{Receiver, Sender};
+use std::thread::JoinHandle;
 use crate::Error;
-use std::sync::mpsc::{channel, Receiver, Sender};
-use std::thread::{spawn, JoinHandle};
 
 /// A worker thread that can be used to run javascript code in a separate thread
 /// Contains a channel pair for communication, and a single runtime instance
@@ -32,81 +9,45 @@ use std::thread::{spawn, JoinHandle};
 /// This allows flexibility in the runtime used by the worker, as well as the types of queries and responses that can be used
 ///
 /// For a simple worker that uses the default runtime, see [worker::DefaultWorker]
-pub struct Worker<W>
+pub struct InnerWorker<W>
 where
-    W: InnerWorker,
+    W: CommonWorker + ?Sized,
 {
     handle: JoinHandle<()>,
     tx: Sender<W::Query>,
     rx: Receiver<W::Response>,
 }
 
-impl<W> Worker<W>
+/// An implementation of the worker trait for a specific runtime
+/// This allows flexibility in the runtime used by the worker
+/// As well as the types of queries and responses that can be used
+///
+/// Implement this trait for a specific runtime to use it with the worker
+/// For an example implementation, see [worker::DefaultWorker]
+pub trait CommonWorker
 where
-    W: InnerWorker,
+    Self: Send,
+    <Self as CommonWorker>::RuntimeOptions: Send + 'static,
+    <Self as CommonWorker>::Query: Send + 'static,
+    <Self as CommonWorker>::Response: Send + 'static,
 {
-    /// Create a new worker instance
-    pub fn new(options: W::RuntimeOptions) -> Result<Self, Error> {
-        let (qtx, qrx) = channel();
-        let (rtx, rrx) = channel();
-        let (init_tx, init_rx) = channel::<Option<Error>>();
+    /// The type of options that can be used to initialize the runtime
+    /// Cannot be `rustyscript::RuntimeOptions` because it is not `Send`
+    type RuntimeOptions;
 
-        let handle = spawn(move || {
-            let rx = qrx;
-            let tx = rtx;
-            let itx = init_tx;
+    /// The type of query that can be sent to the worker
+    /// This should be an enum that contains all possible queries
+    type Query;
 
-            let runtime = match W::init_runtime(options) {
-                Ok(rt) => rt,
-                Err(e) => {
-                    itx.send(Some(e)).unwrap();
-                    return;
-                }
-            };
+    /// The type of response that can be received from the worker
+    /// This should be an enum that contains all possible responses
+    type Response;
+}
 
-            itx.send(None).unwrap();
-            W::thread(runtime, rx, tx);
-        });
-
-        let worker = Self {
-            handle,
-            tx: qtx,
-            rx: rrx,
-        };
-
-        // Wait for initialization to complete
-        match init_rx.recv() {
-            Ok(None) => Ok(worker),
-
-            // Initialization failed
-            Ok(Some(e)) => Err(e),
-
-            // Parser crashed on startup
-            _ => {
-                // This can be replaced with `?` by calling `try_new` on the deno_core::Runtime once that change makes it into a release
-                let e = worker
-                    .handle
-                    .join()
-                    .err()
-                    .and_then(|e| {
-                        e.downcast_ref::<String>()
-                            .cloned()
-                            .or_else(|| e.downcast_ref::<&str>().map(|s| s.to_string()))
-                    })
-                    .unwrap_or_else(|| "Could not start runtime thread".to_string());
-
-                // Remove everything after the words 'Stack backtrace'
-                let e = match e.split("Stack backtrace").next() {
-                    Some(e) => e.trim(),
-                    None => &e,
-                }
-                .to_string();
-
-                Err(Error::Runtime(e))
-            }
-        }
-    }
-
+impl<W> InnerWorker<W>
+where
+    W: CommonWorker + ?Sized,
+{
     /// Send a request to the worker
     /// This will not block the current thread
     /// Will return an error if the worker has stopped or panicked
@@ -141,316 +82,6 @@ where
     }
 }
 
-/// An implementation of the worker trait for a specific runtime
-/// This allows flexibility in the runtime used by the worker
-/// As well as the types of queries and responses that can be used
-///
-/// Implement this trait for a specific runtime to use it with the worker
-/// For an example implementation, see [worker::DefaultWorker]
-pub trait InnerWorker
-where
-    Self: Send,
-    <Self as InnerWorker>::RuntimeOptions: std::marker::Send + 'static,
-    <Self as InnerWorker>::Query: std::marker::Send + 'static,
-    <Self as InnerWorker>::Response: std::marker::Send + 'static,
-{
-    /// The type of runtime used by this worker
-    /// This can just be `rustyscript::Runtime` if you don't need to use a custom runtime
-    type Runtime;
-
-    /// The type of options that can be used to initialize the runtime
-    /// Cannot be `rustyscript::RuntimeOptions` because it is not `Send`
-    type RuntimeOptions;
-
-    /// The type of query that can be sent to the worker
-    /// This should be an enum that contains all possible queries
-    type Query;
-
-    /// The type of response that can be received from the worker
-    /// This should be an enum that contains all possible responses
-    type Response;
-
-    /// Initialize the runtime used by the worker
-    /// This should return a new instance of the runtime that will respond to queries
-    fn init_runtime(options: Self::RuntimeOptions) -> Result<Self::Runtime, Error>;
-
-    /// Handle a query sent to the worker
-    /// Must always return a response of some kind
-    fn handle_query(runtime: &mut Self::Runtime, query: Self::Query) -> Self::Response;
-
-    /// The main thread function that will be run by the worker
-    /// This should handle all incoming queries and send responses back
-    fn thread(mut runtime: Self::Runtime, rx: Receiver<Self::Query>, tx: Sender<Self::Response>) {
-        loop {
-            let msg = match rx.recv() {
-                Ok(msg) => msg,
-                Err(_) => break,
-            };
-
-            let response = Self::handle_query(&mut runtime, msg);
-            tx.send(response).unwrap();
-        }
-    }
-}
-
-/// A worker implementation that uses the default runtime
-/// This is the simplest way to use the worker, as it requires no additional setup
-/// It attempts to provide as much functionality as possible from the standard runtime
-///
-/// Please note that it uses serde_json::Value for queries and responses, which comes with a performance cost
-/// For a more performant worker, or to use extensions and/or loader caches, you'll need to implement your own worker
-pub struct DefaultWorker(Worker<DefaultWorker>);
-impl InnerWorker for DefaultWorker {
-    type Runtime = (
-        crate::Runtime,
-        std::collections::HashMap<deno_core::ModuleId, crate::ModuleHandle>,
-    );
-    type RuntimeOptions = DefaultWorkerOptions;
-    type Query = DefaultWorkerQuery;
-    type Response = DefaultWorkerResponse;
-
-    fn init_runtime(options: Self::RuntimeOptions) -> Result<Self::Runtime, Error> {
-        let runtime = crate::Runtime::new(crate::RuntimeOptions {
-            default_entrypoint: options.default_entrypoint,
-            timeout: options.timeout,
-            ..Default::default()
-        })?;
-        let modules = std::collections::HashMap::new();
-        Ok((runtime, modules))
-    }
-
-    fn handle_query(runtime: &mut Self::Runtime, query: Self::Query) -> Self::Response {
-        let (runtime, modules) = runtime;
-        match query {
-            DefaultWorkerQuery::Stop => Self::Response::Ok(()),
-
-            DefaultWorkerQuery::Eval(code) => match runtime.eval(&code) {
-                Ok(v) => Self::Response::Value(v),
-                Err(e) => Self::Response::Error(e),
-            },
-
-            DefaultWorkerQuery::LoadMainModule(module) => match runtime.load_module(&module) {
-                Ok(handle) => {
-                    let id = handle.id();
-                    modules.insert(id, handle);
-                    Self::Response::ModuleId(id)
-                }
-                Err(e) => Self::Response::Error(e),
-            },
-
-            DefaultWorkerQuery::LoadModule(module) => match runtime.load_module(&module) {
-                Ok(handle) => {
-                    let id = handle.id();
-                    modules.insert(id, handle);
-                    Self::Response::ModuleId(id)
-                }
-                Err(e) => Self::Response::Error(e),
-            },
-
-            DefaultWorkerQuery::CallEntrypoint(id, args) => match modules.get(&id) {
-                Some(handle) => match runtime.call_entrypoint(handle, &args) {
-                    Ok(v) => Self::Response::Value(v),
-                    Err(e) => Self::Response::Error(e),
-                },
-                None => Self::Response::Error(Error::Runtime("Module not found".to_string())),
-            },
-
-            DefaultWorkerQuery::CallFunction(id, name, args) => {
-                let handle = if let Some(id) = id {
-                    match modules.get(&id) {
-                        Some(handle) => Some(handle),
-                        None => {
-                            return Self::Response::Error(Error::Runtime(
-                                "Module not found".to_string(),
-                            ))
-                        }
-                    }
-                } else {
-                    None
-                };
-
-                match runtime.call_function(handle, &name, &args) {
-                    Ok(v) => Self::Response::Value(v),
-                    Err(e) => Self::Response::Error(e),
-                }
-            }
-
-            DefaultWorkerQuery::GetValue(id, name) => {
-                let handle = if let Some(id) = id {
-                    match modules.get(&id) {
-                        Some(handle) => Some(handle),
-                        None => {
-                            return Self::Response::Error(Error::Runtime(
-                                "Module not found".to_string(),
-                            ))
-                        }
-                    }
-                } else {
-                    None
-                };
-
-                match runtime.get_value(handle, &name) {
-                    Ok(v) => Self::Response::Value(v),
-                    Err(e) => Self::Response::Error(e),
-                }
-            }
-        }
-    }
-
-    // Custom thread impl to handle stop
-    fn thread(mut runtime: Self::Runtime, rx: Receiver<Self::Query>, tx: Sender<Self::Response>) {
-        loop {
-            let msg = match rx.recv() {
-                Ok(msg) => msg,
-                Err(_) => break,
-            };
-
-            match &msg {
-                DefaultWorkerQuery::Stop => {
-                    tx.send(Self::Response::Ok(())).unwrap();
-                    break;
-                }
-                _ => {
-                    let response = Self::handle_query(&mut runtime, msg);
-                    tx.send(response).unwrap();
-                }
-            }
-        }
-    }
-}
-impl DefaultWorker {
-    /// Create a new worker instance
-    pub fn new(options: DefaultWorkerOptions) -> Result<Self, Error> {
-        Worker::new(options).map(Self)
-    }
-
-    /// Stop the worker and wait for it to finish
-    /// Consumes the worker and returns an error if the worker panicked
-    pub fn stop(self) -> Result<(), Error> {
-        self.0.send(DefaultWorkerQuery::Stop)?;
-        self.0.join()
-    }
-
-    /// Evaluate a string of javascript code
-    /// Returns the result of the evaluation
-    pub fn eval<T>(&self, code: String) -> Result<T, Error>
-    where
-        T: serde::de::DeserializeOwned,
-    {
-        match self.0.send_and_await(DefaultWorkerQuery::Eval(code))? {
-            DefaultWorkerResponse::Value(v) => Ok(crate::serde_json::from_value(v)?),
-            DefaultWorkerResponse::Error(e) => Err(e),
-            _ => Err(Error::Runtime(
-                "Unexpected response from the worker".to_string(),
-            )),
-        }
-    }
-
-    /// Load a module into the worker as the main module
-    /// Returns the module id of the loaded module
-    pub fn load_main_module(&self, module: crate::Module) -> Result<deno_core::ModuleId, Error> {
-        match self
-            .0
-            .send_and_await(DefaultWorkerQuery::LoadMainModule(module))?
-        {
-            DefaultWorkerResponse::ModuleId(id) => Ok(id),
-            DefaultWorkerResponse::Error(e) => Err(e),
-            _ => Err(Error::Runtime(
-                "Unexpected response from the worker".to_string(),
-            )),
-        }
-    }
-
-    /// Load a module into the worker as a side module
-    /// Returns the module id of the loaded module
-    pub fn load_module(&self, module: crate::Module) -> Result<deno_core::ModuleId, Error> {
-        match self
-            .0
-            .send_and_await(DefaultWorkerQuery::LoadModule(module))?
-        {
-            DefaultWorkerResponse::ModuleId(id) => Ok(id),
-            DefaultWorkerResponse::Error(e) => Err(e),
-            _ => Err(Error::Runtime(
-                "Unexpected response from the worker".to_string(),
-            )),
-        }
-    }
-
-    /// Call the entrypoint function in a module
-    /// Returns the result of the function call
-    /// The module id must be the id of a module loaded with `load_main_module` or `load_module`
-    pub fn call_entrypoint<T>(
-        &self,
-        id: deno_core::ModuleId,
-        args: Vec<crate::serde_json::Value>,
-    ) -> Result<T, Error>
-    where
-        T: serde::de::DeserializeOwned,
-    {
-        match self
-            .0
-            .send_and_await(DefaultWorkerQuery::CallEntrypoint(id, args))?
-        {
-            DefaultWorkerResponse::Value(v) => {
-                crate::serde_json::from_value(v).map_err(Error::from)
-            }
-            DefaultWorkerResponse::Error(e) => Err(e),
-            _ => Err(Error::Runtime(
-                "Unexpected response from the worker".to_string(),
-            )),
-        }
-    }
-
-    /// Call a function in a module
-    /// Returns the result of the function call
-    /// The module id must be the id of a module loaded with `load_main_module` or `load_module`
-    pub fn call_function<T>(
-        &self,
-        module_context: Option<deno_core::ModuleId>,
-        name: String,
-        args: Vec<crate::serde_json::Value>,
-    ) -> Result<T, Error>
-    where
-        T: serde::de::DeserializeOwned,
-    {
-        match self
-            .0
-            .send_and_await(DefaultWorkerQuery::CallFunction(module_context, name, args))?
-        {
-            DefaultWorkerResponse::Value(v) => {
-                crate::serde_json::from_value(v).map_err(Error::from)
-            }
-            DefaultWorkerResponse::Error(e) => Err(e),
-            _ => Err(Error::Runtime(
-                "Unexpected response from the worker".to_string(),
-            )),
-        }
-    }
-
-    /// Get a value from a module
-    /// The module id must be the id of a module loaded with `load_main_module` or `load_module`
-    pub fn get_value<T>(
-        &self,
-        module_context: Option<deno_core::ModuleId>,
-        name: String,
-    ) -> Result<T, Error>
-    where
-        T: serde::de::DeserializeOwned,
-    {
-        match self
-            .0
-            .send_and_await(DefaultWorkerQuery::GetValue(module_context, name))?
-        {
-            DefaultWorkerResponse::Value(v) => {
-                crate::serde_json::from_value(v).map_err(Error::from)
-            }
-            DefaultWorkerResponse::Error(e) => Err(e),
-            _ => Err(Error::Runtime(
-                "Unexpected response from the worker".to_string(),
-            )),
-        }
-    }
-}
 
 /// Options for the default worker
 #[derive(Default, Clone)]
@@ -503,4 +134,749 @@ pub enum DefaultWorkerResponse {
 
     /// An error response
     Error(Error),
+}
+
+#[cfg(feature = "sync-worker")]
+pub mod sync_worker {
+    //! Provides a worker thread that can be used to run javascript code in a separate thread through a channel pair
+    //! It also provides a default worker implementation that can be used without any additional setup:
+    //! ```rust
+    //! use rustyscript::{Error, worker::sync_worker::{InnerWorker, DefaultWorker, DefaultWorkerOptions}};
+    //! use std::time::Duration;
+    //!
+    //! fn main() -> Result<(), Error> {
+    //!     let worker = DefaultWorker::new(DefaultWorkerOptions {
+    //!         default_entrypoint: None,
+    //!         timeout: Duration::from_secs(5),
+    //!     })?;
+    //!
+    //!     worker.register_function("add".to_string(), |args, _state| {
+    //!         let a = args[0].as_i64().unwrap();
+    //!         let b = args[1].as_i64().unwrap();
+    //!         let result = a + b;
+    //!         Ok(result.into())
+    //!     })?;
+    //!     let result: i32 = worker.eval("add(5, 5)".to_string())?;
+    //!     assert_eq!(result, 10);
+    //!     Ok(())
+    //! }
+
+    use crate::Error;
+    use std::sync::mpsc::{channel, Receiver, Sender};
+    use std::thread::spawn;
+    use std::collections::HashMap;
+    use crate::worker::{DefaultWorkerOptions, DefaultWorkerQuery, DefaultWorkerResponse, CommonWorker};
+
+    pub use crate::worker::InnerWorker;
+
+    /// A worker implementation that uses the default runtime
+    /// This is the simplest way to use the worker, as it requires no additional setup
+    /// It attempts to provide as much functionality as possible from the standard runtime
+    ///
+    /// Please note that it uses serde_json::Value for queries and responses, which comes with a performance cost
+    /// For a more performant worker, or to use extensions and/or loader caches, you'll need to implement your own worker
+    pub struct DefaultWorker(InnerWorker<DefaultWorker>);
+
+    impl CommonWorker for DefaultWorker {
+        type RuntimeOptions = DefaultWorkerOptions;
+        type Query = DefaultWorkerQuery;
+        type Response = DefaultWorkerResponse;
+    }
+
+    pub trait SyncWorker: CommonWorker
+    where
+        Self: Send,
+        Self::Runtime: Send,
+    {
+        /// The type of runtime used by this worker
+        /// This can just be `rustyscript::Runtime` if you don't need to use a custom runtime
+        type Runtime;
+
+        /// Create a new worker instance
+        fn new_inner(options: Self::RuntimeOptions) -> Result<InnerWorker<Self>, Error>;
+
+        /// Initialize the runtime used by the worker
+        /// This should return a new instance of the runtime that will respond to queries
+        fn init_runtime(options: Self::RuntimeOptions) -> Result<Self::Runtime, Error>;
+
+        /// Handle a query sent to the worker
+        /// Must always return a response of some kind
+        fn handle_query(runtime: &mut Self::Runtime, query: Self::Query) -> Self::Response;
+
+        /// The main thread function that will be run by the worker
+        /// This should handle all incoming queries and send responses back
+        fn thread(mut runtime: Self::Runtime, rx: Receiver<Self::Query>, tx: Sender<Self::Response>) {
+            loop {
+                let msg = match rx.recv() {
+                    Ok(msg) => msg,
+                    Err(_) => break,
+                };
+
+                let response = Self::handle_query(&mut runtime, msg);
+                tx.send(response).unwrap();
+            }
+        }
+    }
+
+    impl SyncWorker for DefaultWorker {
+        type Runtime = (
+            crate::Runtime,
+            HashMap<deno_core::ModuleId, crate::ModuleHandle>,
+        );
+
+        fn new_inner(options: Self::RuntimeOptions) -> Result<InnerWorker<Self>, Error> {
+            let (qtx, qrx) = channel();
+            let (rtx, rrx) = channel();
+            let (init_tx, init_rx) = channel::<Option<Error>>();
+
+            let handle = spawn(move || {
+                let rx = qrx;
+                let tx = rtx;
+                let itx = init_tx;
+
+                let runtime = match Self::init_runtime(options) {
+                    Ok(rt) => rt,
+                    Err(e) => {
+                        itx.send(Some(e)).unwrap();
+                        return;
+                    }
+                };
+
+                itx.send(None).unwrap();
+                Self::thread(runtime, rx, tx);
+            });
+
+            let worker = InnerWorker {
+                handle,
+                tx: qtx,
+                rx: rrx,
+            };
+
+            // Wait for initialization to complete
+            match init_rx.recv() {
+                Ok(None) => Ok(worker),
+
+                // Initialization failed
+                Ok(Some(e)) => Err(e),
+
+                // Parser crashed on startup
+                _ => {
+                    // This can be replaced with `?` by calling `try_new` on the deno_core::Runtime once that change makes it into a release
+                    let e = worker
+                        .handle
+                        .join()
+                        .err()
+                        .and_then(|e| {
+                            e.downcast_ref::<String>()
+                                .cloned()
+                                .or_else(|| e.downcast_ref::<&str>().map(|s| s.to_string()))
+                        })
+                        .unwrap_or_else(|| "Could not start runtime thread".to_string());
+
+                    // Remove everything after the words 'Stack backtrace'
+                    let e = match e.split("Stack backtrace").next() {
+                        Some(e) => e.trim(),
+                        None => &e,
+                    }
+                        .to_string();
+
+                    Err(Error::Runtime(e))
+                }
+            }
+        }
+
+        fn init_runtime(options: Self::RuntimeOptions) -> Result<Self::Runtime, Error> {
+            let runtime = crate::Runtime::new(crate::RuntimeOptions {
+                default_entrypoint: options.default_entrypoint,
+                timeout: options.timeout,
+                ..Default::default()
+            })?;
+            let modules = std::collections::HashMap::new();
+            Ok((runtime, modules))
+        }
+
+        fn handle_query(runtime: &mut Self::Runtime, query: Self::Query) -> Self::Response {
+            let (runtime, modules) = runtime;
+            match query {
+                DefaultWorkerQuery::Stop => Self::Response::Ok(()),
+
+                DefaultWorkerQuery::Eval(code) => match runtime.eval(&code) {
+                    Ok(v) => Self::Response::Value(v),
+                    Err(e) => Self::Response::Error(e),
+                },
+
+                DefaultWorkerQuery::LoadMainModule(module) => match runtime.load_module(&module) {
+                    Ok(handle) => {
+                        let id = handle.id();
+                        modules.insert(id, handle);
+                        Self::Response::ModuleId(id)
+                    }
+                    Err(e) => Self::Response::Error(e),
+                },
+
+                DefaultWorkerQuery::LoadModule(module) => match runtime.load_module(&module) {
+                    Ok(handle) => {
+                        let id = handle.id();
+                        modules.insert(id, handle);
+                        Self::Response::ModuleId(id)
+                    }
+                    Err(e) => Self::Response::Error(e),
+                },
+
+                DefaultWorkerQuery::CallEntrypoint(id, args) => match modules.get(&id) {
+                    Some(handle) => match runtime.call_entrypoint(handle, &args) {
+                        Ok(v) => Self::Response::Value(v),
+                        Err(e) => Self::Response::Error(e),
+                    },
+                    None => Self::Response::Error(Error::Runtime("Module not found".to_string())),
+                },
+
+                DefaultWorkerQuery::CallFunction(id, name, args) => {
+                    let handle = if let Some(id) = id {
+                        match modules.get(&id) {
+                            Some(handle) => Some(handle),
+                            None => {
+                                return Self::Response::Error(Error::Runtime(
+                                    "Module not found".to_string(),
+                                ))
+                            }
+                        }
+                    } else {
+                        None
+                    };
+
+                    match runtime.call_function(handle, &name, &args) {
+                        Ok(v) => Self::Response::Value(v),
+                        Err(e) => Self::Response::Error(e),
+                    }
+                }
+
+                DefaultWorkerQuery::GetValue(id, name) => {
+                    let handle = if let Some(id) = id {
+                        match modules.get(&id) {
+                            Some(handle) => Some(handle),
+                            None => {
+                                return Self::Response::Error(Error::Runtime(
+                                    "Module not found".to_string(),
+                                ))
+                            }
+                        }
+                    } else {
+                        None
+                    };
+
+                    match runtime.get_value(handle, &name) {
+                        Ok(v) => Self::Response::Value(v),
+                        Err(e) => Self::Response::Error(e),
+                    }
+                }
+            }
+        }
+
+        // Custom thread impl to handle stop
+        fn thread(mut runtime: Self::Runtime, rx: Receiver<Self::Query>, tx: Sender<Self::Response>) {
+            loop {
+                let msg = match rx.recv() {
+                    Ok(msg) => msg,
+                    Err(_) => break,
+                };
+
+                match &msg {
+                    DefaultWorkerQuery::Stop => {
+                        tx.send(Self::Response::Ok(())).unwrap();
+                        break;
+                    }
+                    _ => {
+                        let response = Self::handle_query(&mut runtime, msg);
+                        tx.send(response).unwrap();
+                    }
+                }
+            }
+        }
+    }
+
+    impl DefaultWorker {
+        /// Create a new worker instance
+        pub fn new(options: DefaultWorkerOptions) -> Result<Self, Error> {
+            Self::new_inner(options).map(Self)
+        }
+
+        /// Stop the worker and wait for it to finish
+        /// Consumes the worker and returns an error if the worker panicked
+        pub fn stop(self) -> Result<(), Error> {
+            self.0.send(DefaultWorkerQuery::Stop)?;
+            self.0.join()
+        }
+
+        /// Evaluate a string of javascript code
+        /// Returns the result of the evaluation
+        pub fn eval<T>(&self, code: String) -> Result<T, Error>
+        where
+            T: serde::de::DeserializeOwned,
+        {
+            match self.0.send_and_await(DefaultWorkerQuery::Eval(code))? {
+                DefaultWorkerResponse::Value(v) => Ok(crate::serde_json::from_value(v)?),
+                DefaultWorkerResponse::Error(e) => Err(e),
+                _ => Err(Error::Runtime(
+                    "Unexpected response from the worker".to_string(),
+                )),
+            }
+        }
+
+        /// Load a module into the worker as the main module
+        /// Returns the module id of the loaded module
+        pub fn load_main_module(&self, module: crate::Module) -> Result<deno_core::ModuleId, Error> {
+            match self
+                .0
+                .send_and_await(DefaultWorkerQuery::LoadMainModule(module))?
+            {
+                DefaultWorkerResponse::ModuleId(id) => Ok(id),
+                DefaultWorkerResponse::Error(e) => Err(e),
+                _ => Err(Error::Runtime(
+                    "Unexpected response from the worker".to_string(),
+                )),
+            }
+        }
+
+        /// Load a module into the worker as a side module
+        /// Returns the module id of the loaded module
+        pub fn load_module(&self, module: crate::Module) -> Result<deno_core::ModuleId, Error> {
+            match self
+                .0
+                .send_and_await(DefaultWorkerQuery::LoadModule(module))?
+            {
+                DefaultWorkerResponse::ModuleId(id) => Ok(id),
+                DefaultWorkerResponse::Error(e) => Err(e),
+                _ => Err(Error::Runtime(
+                    "Unexpected response from the worker".to_string(),
+                )),
+            }
+        }
+
+        /// Call the entrypoint function in a module
+        /// Returns the result of the function call
+        /// The module id must be the id of a module loaded with `load_main_module` or `load_module`
+        pub fn call_entrypoint<T>(
+            &self,
+            id: deno_core::ModuleId,
+            args: Vec<crate::serde_json::Value>,
+        ) -> Result<T, Error>
+        where
+            T: serde::de::DeserializeOwned,
+        {
+            match self
+                .0
+                .send_and_await(DefaultWorkerQuery::CallEntrypoint(id, args))?
+            {
+                DefaultWorkerResponse::Value(v) => {
+                    crate::serde_json::from_value(v).map_err(Error::from)
+                }
+                DefaultWorkerResponse::Error(e) => Err(e),
+                _ => Err(Error::Runtime(
+                    "Unexpected response from the worker".to_string(),
+                )),
+            }
+        }
+
+        /// Call a function in a module
+        /// Returns the result of the function call
+        /// The module id must be the id of a module loaded with `load_main_module` or `load_module`
+        pub fn call_function<T>(
+            &self,
+            module_context: Option<deno_core::ModuleId>,
+            name: String,
+            args: Vec<crate::serde_json::Value>,
+        ) -> Result<T, Error>
+        where
+            T: serde::de::DeserializeOwned,
+        {
+            match self
+                .0
+                .send_and_await(DefaultWorkerQuery::CallFunction(module_context, name, args))?
+            {
+                DefaultWorkerResponse::Value(v) => {
+                    crate::serde_json::from_value(v).map_err(Error::from)
+                }
+                DefaultWorkerResponse::Error(e) => Err(e),
+                _ => Err(Error::Runtime(
+                    "Unexpected response from the worker".to_string(),
+                )),
+            }
+        }
+
+        /// Get a value from a module
+        /// The module id must be the id of a module loaded with `load_main_module` or `load_module`
+        pub fn get_value<T>(
+            &self,
+            module_context: Option<deno_core::ModuleId>,
+            name: String,
+        ) -> Result<T, Error>
+        where
+            T: serde::de::DeserializeOwned,
+        {
+            match self
+                .0
+                .send_and_await(DefaultWorkerQuery::GetValue(module_context, name))?
+            {
+                DefaultWorkerResponse::Value(v) => {
+                    crate::serde_json::from_value(v).map_err(Error::from)
+                }
+                DefaultWorkerResponse::Error(e) => Err(e),
+                _ => Err(Error::Runtime(
+                    "Unexpected response from the worker".to_string(),
+                )),
+            }
+        }
+    }
+}
+
+#[cfg(feature = "async-worker")]
+pub mod async_worker {
+    use crate::Error;
+    use std::sync::mpsc::{channel, Receiver, Sender};
+    use std::thread::{spawn, JoinHandle};
+    use dashmap::DashMap;
+    use async_trait::async_trait;
+    use log::error;
+    use crate::worker::{CommonWorker, DefaultWorkerOptions, DefaultWorkerQuery, DefaultWorkerResponse};
+
+    pub use crate::worker::InnerWorker;
+
+    pub struct DefaultWorker(InnerWorker<DefaultWorker>);
+
+    impl CommonWorker for DefaultWorker {
+        type RuntimeOptions = DefaultWorkerOptions;
+        type Query = DefaultWorkerQuery;
+        type Response = DefaultWorkerResponse;
+    }
+
+    pub trait AsyncWorker: CommonWorker
+    where
+        Self: Send,
+    {
+        type Runtime;
+
+        /// Create a new worker instance
+        fn new_inner(options: Self::RuntimeOptions) -> Result<InnerWorker<Self>, Error>;
+
+        /// Handle a query sent to the worker
+        /// Must always return a response of some kind
+        // Returning a future which is not Send is okay here since it will be awaited on the same thread
+        fn handle_query(runtime: &mut Self::Runtime, query: Self::Query) -> impl std::future::Future<Output=Self::Response>;
+
+        /// The main thread function that will be run by the worker
+        /// This should handle all incoming queries and send responses back
+        // Returning a future which is not Send is okay here since it will be awaited on the same thread
+        fn thread(options: Self::RuntimeOptions, rx: Receiver<Self::Query>, tx: Sender<Self::Response>, itx: Sender<Option<Error>>) -> impl std::future::Future<Output=Result<(), Error>>;
+    }
+
+    impl AsyncWorker for DefaultWorker {
+        type Runtime = (crate::AsyncRuntime, DashMap<deno_core::ModuleId, crate::ModuleHandle>);
+
+        fn new_inner(options: Self::RuntimeOptions) -> Result<InnerWorker<Self>, Error> {
+            let (qtx, qrx) = channel();
+            let (rtx, rrx) = channel();
+            let (init_tx, init_rx) = channel::<Option<Error>>();
+
+            let handle = spawn(move || {
+                let rx = qrx;
+                let tx = rtx;
+                let itx = init_tx;
+
+                let itx_move = itx.clone();
+                let init = move || {
+                    let async_rt = tokio::runtime::Builder::new_current_thread().enable_all().build()?;
+
+                    async_rt.block_on(async move {
+                        Self::thread(options, rx, tx, itx_move).await?;
+                        Ok::<(), Error>(())
+                    })?;
+                    Ok::<(), Error>(())
+                };
+
+                if let Err(e) = init() {
+                    let _ = itx.send(Some(e));
+                    return;
+                };
+            });
+
+            let worker = InnerWorker {
+                handle,
+                tx: qtx,
+                rx: rrx,
+            };
+
+            match init_rx.recv() {
+                Ok(None) => Ok(worker),
+
+                // Initialization failed
+                Ok(Some(e)) => Err(e),
+
+                // Parser crashed on startup
+                _ => {
+                    // This can be replaced with `?` by calling `try_new` on the deno_core::Runtime once that change makes it into a release
+                    let e = worker
+                        .handle
+                        .join()
+                        .err()
+                        .and_then(|e| {
+                            e.downcast_ref::<String>()
+                                .cloned()
+                                .or_else(|| e.downcast_ref::<&str>().map(|s| s.to_string()))
+                        })
+                        .unwrap_or_else(|| "Could not start runtime thread".to_string());
+
+                    // Remove everything after the words 'Stack backtrace'
+                    let e = match e.split("Stack backtrace").next() {
+                        Some(e) => e.trim(),
+                        None => &e,
+                    }
+                        .to_string();
+
+                    Err(Error::Runtime(e))
+                }
+            }
+        }
+
+        async fn handle_query(runtime: &mut Self::Runtime, query: Self::Query) -> Self::Response {
+            let (runtime, modules) = runtime;
+            match query {
+                DefaultWorkerQuery::Stop => Self::Response::Ok(()),
+
+                DefaultWorkerQuery::Eval(code) => match runtime.eval(&code) {
+                    Ok(v) => Self::Response::Value(v),
+                    Err(e) => Self::Response::Error(e),
+                },
+
+                DefaultWorkerQuery::LoadMainModule(module) => match runtime.load_module(&module).await {
+                    Ok(handle) => {
+                        let id = handle.id();
+                        modules.insert(id, handle);
+                        Self::Response::ModuleId(id)
+                    }
+                    Err(e) => Self::Response::Error(e),
+                },
+
+                DefaultWorkerQuery::LoadModule(module) => match runtime.load_module(&module).await {
+                    Ok(handle) => {
+                        let id = handle.id();
+                        modules.insert(id, handle);
+                        Self::Response::ModuleId(id)
+                    }
+                    Err(e) => Self::Response::Error(e),
+                },
+
+                DefaultWorkerQuery::CallEntrypoint(id, args) => match modules.get(&id) {
+                    Some(handle) => match runtime.call_entrypoint(handle.value(), &args).await {
+                        Ok(v) => Self::Response::Value(v),
+                        Err(e) => Self::Response::Error(e),
+                    },
+                    None => Self::Response::Error(Error::Runtime("Module not found".to_string())),
+                },
+
+                DefaultWorkerQuery::CallFunction(id, name, args) => {
+                    let handle = if let Some(id) = id {
+                        match modules.get(&id) {
+                            Some(handle) => {
+                                Some(handle.clone())
+                            }
+                            None => {
+                                return Self::Response::Error(Error::Runtime(
+                                    "Module not found".to_string(),
+                                ))
+                            }
+                        }
+                    } else {
+                        None
+                    };
+
+                    match runtime.call_function(handle, &name, args.into_boxed_slice()).await {
+                        Ok(v) => Self::Response::Value(v),
+                        Err(e) => Self::Response::Error(e),
+                    }
+                }
+
+                DefaultWorkerQuery::GetValue(id, name) => {
+                    let handle = if let Some(id) = id {
+                        match modules.get(&id) {
+                            Some(handle) => Some(handle.clone()),
+                            None => {
+                                return Self::Response::Error(Error::Runtime(
+                                    "Module not found".to_string(),
+                                ))
+                            }
+                        }
+                    } else {
+                        None
+                    };
+
+                    match runtime.get_value(handle, &name).await {
+                        Ok(v) => Self::Response::Value(v),
+                        Err(e) => Self::Response::Error(e),
+                    }
+                }
+            }
+        }
+
+        async fn thread(options: Self::RuntimeOptions, rx: Receiver<Self::Query>, tx: Sender<Self::Response>, itx: Sender<Option<Error>>) -> Result<(), Error> {
+            let runtime = crate::AsyncRuntime::new(crate::RuntimeOptions {
+                default_entrypoint: options.default_entrypoint.clone(),
+                timeout: options.timeout,
+                ..Default::default()
+            })?;
+            let modules = DashMap::new();
+            let mut runtime = (runtime, modules);
+            itx.send(None).unwrap();
+
+            loop {
+                let msg = match rx.recv() {
+                    Ok(msg) => msg,
+                    Err(_) => break,
+                };
+
+                let response = Self::handle_query(&mut runtime, msg).await;
+
+                if let Err(e) = tx.send(response) {
+                    error!("{:?}", e);
+                    break;
+                };
+            }
+            Ok(())
+        }
+    }
+
+    // TODO: make it truly async
+    impl DefaultWorker {
+        /// Create a new worker instance
+        pub fn new(options: DefaultWorkerOptions) -> Result<Self, Error> {
+            Self::new_inner(options).map(Self)
+        }
+
+        /// Stop the worker and wait for it to finish
+        /// Consumes the worker and returns an error if the worker panicked
+        pub fn stop(self) -> Result<(), Error> {
+            self.0.send(DefaultWorkerQuery::Stop)?;
+            self.0.join()
+        }
+
+        /// Evaluate a string of javascript code
+        /// Returns the result of the evaluation
+        pub fn eval<T>(&self, code: String) -> Result<T, Error>
+        where
+            T: serde::de::DeserializeOwned,
+        {
+            match self.0.send_and_await(DefaultWorkerQuery::Eval(code))? {
+                DefaultWorkerResponse::Value(v) => Ok(crate::serde_json::from_value(v)?),
+                DefaultWorkerResponse::Error(e) => Err(e),
+                _ => Err(Error::Runtime(
+                    "Unexpected response from the worker".to_string(),
+                )),
+            }
+        }
+
+        /// Load a module into the worker as the main module
+        /// Returns the module id of the loaded module
+        pub fn load_main_module(&self, module: crate::Module) -> Result<deno_core::ModuleId, Error> {
+            match self
+                .0
+                .send_and_await(DefaultWorkerQuery::LoadMainModule(module))?
+            {
+                DefaultWorkerResponse::ModuleId(id) => Ok(id),
+                DefaultWorkerResponse::Error(e) => Err(e),
+                _ => Err(Error::Runtime(
+                    "Unexpected response from the worker".to_string(),
+                )),
+            }
+        }
+
+        /// Load a module into the worker as a side module
+        /// Returns the module id of the loaded module
+        pub fn load_module(&self, module: crate::Module) -> Result<deno_core::ModuleId, Error> {
+            match self
+                .0
+                .send_and_await(DefaultWorkerQuery::LoadModule(module))?
+            {
+                DefaultWorkerResponse::ModuleId(id) => Ok(id),
+                DefaultWorkerResponse::Error(e) => Err(e),
+                _ => Err(Error::Runtime(
+                    "Unexpected response from the worker".to_string(),
+                )),
+            }
+        }
+
+        /// Call the entrypoint function in a module
+        /// Returns the result of the function call
+        /// The module id must be the id of a module loaded with `load_main_module` or `load_module`
+        pub fn call_entrypoint<T>(
+            &self,
+            id: deno_core::ModuleId,
+            args: Vec<crate::serde_json::Value>,
+        ) -> Result<T, Error>
+        where
+            T: serde::de::DeserializeOwned,
+        {
+            match self
+                .0
+                .send_and_await(DefaultWorkerQuery::CallEntrypoint(id, args))?
+            {
+                DefaultWorkerResponse::Value(v) => {
+                    crate::serde_json::from_value(v).map_err(Error::from)
+                }
+                DefaultWorkerResponse::Error(e) => Err(e),
+                _ => Err(Error::Runtime(
+                    "Unexpected response from the worker".to_string(),
+                )),
+            }
+        }
+
+        /// Call a function in a module
+        /// Returns the result of the function call
+        /// The module id must be the id of a module loaded with `load_main_module` or `load_module`
+        pub fn call_function<T>(
+            &self,
+            module_context: Option<deno_core::ModuleId>,
+            name: String,
+            args: Vec<crate::serde_json::Value>,
+        ) -> Result<T, Error>
+        where
+            T: serde::de::DeserializeOwned,
+        {
+            match self
+                .0
+                .send_and_await(DefaultWorkerQuery::CallFunction(module_context, name, args))?
+            {
+                DefaultWorkerResponse::Value(v) => {
+                    crate::serde_json::from_value(v).map_err(Error::from)
+                }
+                DefaultWorkerResponse::Error(e) => Err(e),
+                _ => Err(Error::Runtime(
+                    "Unexpected response from the worker".to_string(),
+                )),
+            }
+        }
+
+        /// Get a value from a module
+        /// The module id must be the id of a module loaded with `load_main_module` or `load_module`
+        pub fn get_value<T>(
+            &self,
+            module_context: Option<deno_core::ModuleId>,
+            name: String,
+        ) -> Result<T, Error>
+        where
+            T: serde::de::DeserializeOwned,
+        {
+            match self
+                .0
+                .send_and_await(DefaultWorkerQuery::GetValue(module_context, name))?
+            {
+                DefaultWorkerResponse::Value(v) => {
+                    crate::serde_json::from_value(v).map_err(Error::from)
+                }
+                DefaultWorkerResponse::Error(e) => Err(e),
+                _ => Err(Error::Runtime(
+                    "Unexpected response from the worker".to_string(),
+                )),
+            }
+        }
+    }
 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -581,11 +581,11 @@ pub mod async_worker {
 
         fn send(&self, query: Self::Query) -> Result<(), Error>;
 
-        async fn send_async(&self, query: Self::Query) -> Result<(), Error>;
+        fn send_async(&self, query: Self::Query) -> impl Future<Output=Result<(), Error>> + Send;
 
-        async fn receive(&self) -> Result<Self::Response, Error>;
+        fn receive(&self) -> impl Future<Output=Result<Self::Response, Error>> + Send;
 
-        async fn send_and_await(&self, query: Self::Query) -> Result<Self::Response, Error>;
+        fn send_and_await(&self, query: Self::Query) -> impl Future<Output=Result<Self::Response, Error>> + Send;
 
         /// Create a new worker instance
         fn new_inner(options: Self::RuntimeOptions) -> impl Future<Output=Result<InnerWorker<Self>, Error>>;


### PR DESCRIPTION
## Problems to solve
- Current sync API of `Runtime` creates a new tokio runtime on each operation, which is wasting resources.
- It's hard to serve background workers since current API is blocking and being impossible to exchange data with on-going function calls
- Missing approachs to integrate with big projects running with a multi-threaded tokio runtime

## To-do
- [x] Separate current sync API from new async API by cargo features
- [x] `AsyncRuntime`: Deno wrapper that works within a single-threaded tokio runtime
- [x] `AsyncWorker`: Worker that works with its own thread and tokio runtime 
- [ ] Handle event loop within`AsyncRuntime` to make js async function calls no more blocking current thread to allow concurrent js async function calls
- [x] Migrate the `DefaultWorker` for `AsyncWorker` trait to non-blocking async API
- [ ] Migrate the `DefaultWorker` for `SyncWorker` trait to work with `AsyncRuntime`
- [ ] Unit tests
- [ ] Deprecates the sync `SyncRuntime`(`Runtime` in current version)