### PR TITLE
WIP Add custom import schemes (no new trait)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ web = ["console", "url", "crypto", "deno_web", "deno_tls", "deno_fetch", "url_im
 # Features for the module loader
 fs_import = []
 url_import = ["reqwest"]
+custom_import = []
 
 # Enables the use of the SnapshotBuilder
 snapshot_builder = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,6 +238,9 @@ pub use runtime::{Runtime, RuntimeOptions, Undefined};
 pub use utilities::{evaluate, import, resolve_path, validate};
 pub use v8_value::JsFunction;
 
+#[cfg(feature = "url_import")]
+pub use module_loader::ImportHandler;
+
 #[cfg(test)]
 mod test {
     #[test]


### PR DESCRIPTION
This is a simpler implementation of the custom imports feature I previously proposed.
In this iteration, instead of providing structs that implement a trait, the user can provide a HashMap of boxed functions keyed by strings which correspond to URL schemes.
While I would have liked for custom import handlers to store data in a struct, I figured making this functionality presentable first is more important.
This works with existing examples, but isn't polished yet. Any advice is appreciated.