### PR TITLE
Deprecate old approach for argument encoding, with faster alternative

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,23 @@
+name: Docs
+# By a huge margin the slowest test, so we run it separately
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    # Run tests with all features
+    - name: Run complete tests
+      run: cargo test --all-features --doc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2864,7 +2864,7 @@ dependencies = [
 
 [[package]]
 name = "rustyscript"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "deno_ast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2884,6 +2884,7 @@ dependencies = [
  "libc",
  "nix 0.29.0",
  "once_cell",
+ "paste",
  "reqwest",
  "rustyline",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "rustyscript"
 description = "Effortless JS Integration for Rust"
 edition = "2021"
 license = "MIT OR Apache-2.0"
-version = "0.5.3"
+version = "0.6.0"
 repository = "https://github.com/rscarson/rustyscript"
 
 keywords = ["rust", "javascript", "deno", "runtime", "embedding"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["web-programming", "network-programming", "api-bindings", "compile
 readme = "readme.md"
 
 [features]
-default = ["worker", "web_stub", "console", "url", "crypto"]
+default = ["worker", "web_stub", "console", "url", "crypto", "web"]
 no_extensions = []
 all = ["web", "io", "webstorage", "cache", "websocket"]
 
@@ -83,6 +83,9 @@ worker = []
 [dependencies]
 thiserror = "1.0.62"
 serde = "1.0.204"
+
+# Used to generate identifiers for callbacks
+paste = "1.0.15"
 
 # The deno runtime itself, and the webidl extension for the web APIs
 deno_core = "0.293.0"

--- a/examples/custom_runtimes.rs
+++ b/examples/custom_runtimes.rs
@@ -11,9 +11,7 @@
 /// Extensions consist of a set of #[op2] functions, an extension! macro,
 /// and one or more optional JS modules.
 ///
-use rustyscript::{
-    module, serde_json, Error, Module, ModuleHandle, Runtime, RuntimeOptions, StaticModule,
-};
+use rustyscript::{module, Error, Module, ModuleHandle, Runtime, RuntimeOptions, StaticModule};
 use std::time::Duration;
 
 // See example_extension for a demonstration
@@ -52,7 +50,7 @@ impl MyRuntime {
         &mut self,
         module_context: &ModuleHandle,
         name: &str,
-        args: &[serde_json::Value],
+        args: &impl serde::ser::Serialize,
     ) -> Result<T, Error>
     where
         T: deno_core::serde::de::DeserializeOwned,

--- a/examples/default_threaded_worker.rs
+++ b/examples/default_threaded_worker.rs
@@ -2,7 +2,7 @@
 /// This example shows how to use the threaded worker feature using the default worker implementation
 /// In this example we load a module, and execute a function from it
 ///
-use rustyscript::{json_args, worker::DefaultWorker, Error, Module};
+use rustyscript::{worker::DefaultWorker, Error, Module};
 
 fn main() -> Result<(), Error> {
     let worker = DefaultWorker::new(Default::default())?;
@@ -10,11 +10,8 @@ fn main() -> Result<(), Error> {
     let module = Module::new("test.js", "export function add(a, b) { return a + b; }");
     let module_id = worker.load_module(module)?;
 
-    let result: i32 = worker.call_function(
-        Some(module_id),
-        "add".to_string(),
-        json_args!(1, 2).to_vec(),
-    )?;
+    let result: i32 =
+        worker.call_function(Some(module_id), "add".to_string(), vec![1.into(), 2.into()])?;
     assert_eq!(result, 3);
     Ok(())
 }

--- a/src/ext/mod.rs
+++ b/src/ext/mod.rs
@@ -80,7 +80,7 @@ impl Default for ExtensionOptions {
 
 ///
 /// Add up all required extensions
-pub fn all_extensions(
+pub(crate) fn all_extensions(
     user_extensions: Vec<Extension>,
     options: ExtensionOptions,
 ) -> Vec<Extension> {
@@ -124,7 +124,7 @@ pub fn all_extensions(
 
 ///
 /// Add up all required extensions, in snapshot mode
-pub fn all_snapshot_extensions(
+pub(crate) fn all_snapshot_extensions(
     user_extensions: Vec<Extension>,
     options: ExtensionOptions,
 ) -> Vec<Extension> {

--- a/src/ext/rustyscript/callbacks.rs
+++ b/src/ext/rustyscript/callbacks.rs
@@ -1,52 +1,161 @@
+#![allow(dead_code)]
+use std::{future::Future, pin::Pin, rc::Rc};
+
 use crate::Error;
-use deno_core::v8::{self, HandleScope};
-use std::{future::Future, pin::Pin};
+use deno_core::{op2, serde_json, v8, OpState};
+use paste::paste;
 
-/// Macro to generate async functions
-macro_rules! codegen_function2 {
-    (|$($n:ident:$t:ty),+| $body:block) => {
-        (|| -> Box<dyn RsFunction> {
-            Box::new(|scope: &mut $crate::deno_core::v8::HandleScope, args: Vec<$crate::deno_core::v8::Global<$crate::deno_core::v8::Value>>| Box::pin(async move {
-                let mut args = args.into_iter();
-                $(
-                    // Convert `Value` to `$t`
-                    let $n = args.next()
-                        .ok_or($crate::error::Error::Runtime(format!("Wrong number of arguments")))?;
-                    let $n = $crate::deno_core::v8::Local::new(scope, $n);
-                    let $n:$t = $crate::deno_core::serde_v8::from_v8(scope, $n)?;
-                )+
+pub trait RsStoredCallback: 'static {
+    fn call(
+        &self,
+        args: deno_core::serde_json::Value,
+    ) -> Pin<Box<dyn Future<Output = Result<deno_core::serde_json::Value, Error>>>>;
 
-                // Execute the function
-                let v = $body;
-
-                // Convert the result to a `v8::Global`
-                let v = $crate::deno_core::serde_v8::to_v8(scope, v)?;
-                let v = $crate::deno_core::v8::Global::new(scope, v);
-                Ok::<_, $crate::error::Error>(v)
-            }))
-        })()
-    };
+    fn encode_args(
+        &self,
+        args: v8::Global<v8::Value>,
+        scope: &mut v8::HandleScope<'_>,
+    ) -> Result<deno_core::serde_json::Value, Error>;
 }
 
-pub type RsPromise<'a> = Pin<Box<dyn Future<Output = Result<v8::Global<v8::Value>, Error>> + 'a>>;
-pub trait RsFunction:
-    'static + for<'a> Fn(&'a mut HandleScope, Vec<v8::Global<v8::Value>>) -> RsPromise<'a>
-{
-}
-impl<F> RsFunction for F where
-    F: 'static + for<'a> Fn(&'a mut HandleScope, Vec<v8::Global<v8::Value>>) -> RsPromise<'a>
-{
-}
+pub trait RsCallback: 'static {
+    /// A tuple of the arguments that the function takes
+    type Arguments: serde::ser::Serialize + serde::de::DeserializeOwned;
 
-#[cfg(test)]
-mod test {
-    use super::*;
-    #[test]
-    fn test_async() {
-        let mut runtime = crate::Runtime::new(Default::default()).unwrap();
-        let f = codegen_function2!(|filename: String| { std::future::ready(filename).await });
-        runtime.register_function2("test", f);
+    /// The return type of the function
+    type Return: serde::ser::Serialize + 'static;
 
-        runtime.eval("rustyscript.functions2.test('foo')").unwrap();
+    /// Function body
+    async fn body(args: Self::Arguments) -> Result<Self::Return, Error>;
+
+    /// Convert a series of v8::Value objects into a tuple of arguments
+    fn args_from_v8(
+        args: Vec<v8::Global<v8::Value>>,
+        scope: &mut v8::HandleScope,
+    ) -> Result<Self::Arguments, Error>;
+
+    fn slow_args_from_v8(
+        args: Vec<v8::Global<v8::Value>>,
+        scope: &mut v8::HandleScope,
+    ) -> Result<deno_core::serde_json::Value, Error> {
+        let args = Self::args_from_v8(args, scope)?;
+        deno_core::serde_json::to_value(args).map_err(Error::from)
     }
+
+    /// Convert a series of v8::Value objects into a tuple of arguments
+    fn decode_v8(
+        args: v8::Global<v8::Value>,
+        scope: &mut v8::HandleScope,
+    ) -> Result<Self::Arguments, Error> {
+        let args = v8::Local::new(scope, args);
+        let args = match args.is_array() {
+            false => vec![v8::Global::new(scope, args)],
+            true => {
+                let args: v8::Local<v8::Array> = v8::Local::new(scope, args).try_into()?;
+                let len = args.length() as usize;
+                let mut result = Vec::with_capacity(len);
+                for i in 0..len {
+                    let index = v8::Integer::new(scope, i as i32);
+                    let value = args.get(scope, index.into()).unwrap();
+                    result.push(v8::Global::new(scope, value));
+                }
+                result
+            }
+        };
+
+        Self::args_from_v8(args, scope)
+    }
+
+    /// Call the function
+    async fn call(
+        args: v8::Global<v8::Value>,
+        scope: &mut v8::HandleScope<'_>,
+    ) -> Result<Self::Return, Error> {
+        let args = Self::decode_v8(args, scope)?;
+        Self::body(args).await
+    }
+}
+
+macro_rules! codegen_function {
+    ($(#[doc = $doc:literal])* fn $name:ident ($($n:ident:$t:ty),+ $(,)?) -> $r:ty $body:block ) => {
+        paste! {
+            #[allow(non_camel_case_types)]
+            $(#[doc = $doc])*
+            struct [< rscallback_ $name >]();
+            impl RsCallback for [< rscallback_ $name >] {
+                type Arguments = ($($t,)+);
+                type Return = $r;
+
+                fn args_from_v8(
+                    args: Vec<v8::Global<v8::Value>>,
+                    scope: &mut v8::HandleScope,
+                ) -> Result<Self::Arguments, $crate::Error> {
+                    let mut args = args.into_iter();
+                    $(
+                        let next = args.next().ok_or($crate::Error::Runtime(format!("Missing argument {} for {}", stringify!($n), stringify!($name))))?;
+                        let next = $crate::deno_core::v8::Local::new(scope, next);
+                        let $n:$t = $crate::deno_core::serde_v8::from_v8(scope, next)?;
+                    )+
+                    Ok(($($n,)+))
+                }
+
+                async fn body(($($n,)+): Self::Arguments) -> Result<Self::Return, $crate::Error> {
+                    $body
+                }
+            }
+            impl RsStoredCallback for [< rscallback_ $name >] {
+                fn call(&self, args: $crate::deno_core::serde_json::Value)
+                    -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<$crate::deno_core::serde_json::Value, $crate::Error>>>> {
+                    Box::pin(async move {
+                        let args: <Self as RsCallback>::Arguments = $crate::deno_core::serde_json::from_value(args).map_err($crate::Error::from)?;
+
+                        let v = Self::body(args).await?;
+                        $crate::deno_core::serde_json::to_value(v).map_err($crate::Error::from)
+                    })
+                }
+
+                fn encode_args(&self, args: $crate::deno_core::v8::Global<$crate::deno_core::v8::Value>, scope: &mut $crate::deno_core::v8::HandleScope<'_>) -> Result<$crate::deno_core::serde_json::Value, $crate::Error> {
+                    let args = Self::decode_v8(args, scope)?;
+                    Ok($crate::serde_json::to_value(args)?)
+                }
+            }
+        }
+    }
+}
+
+macro_rules! rs_fn {
+    ($($(#[doc = $doc:literal])* fn $name:ident ($($n:ident:$t:ty),+ $(,)?) -> $r:ty $body:block )+) => {
+        $(codegen_function! { fn $name ($($n:$t),+) -> $r $body })+
+    }
+}
+
+rs_fn! {
+    /// test
+    fn add(a: i64, b: i64) -> i64 {
+        Ok(a + b)
+    }
+}
+
+#[op2(async)]
+#[serde]
+pub async fn run_rscallback<T: RsCallback>(
+    #[serde] args: T::Arguments,
+) -> Result<T::Return, Error> {
+    T::body(args).await
+}
+
+type CallbackTable = std::collections::HashMap<String, Rc<Box<dyn RsStoredCallback>>>;
+
+#[op2(async)]
+#[serde]
+pub fn rscallback(
+    #[string] name: String,
+    #[serde] args: deno_core::serde_json::Value,
+    state: &mut OpState,
+) -> impl std::future::Future<Output = Result<serde_json::Value, Error>> {
+    let callback = state
+        .try_borrow::<CallbackTable>()
+        .and_then(|t| t.get(&name).cloned())
+        .ok_or_else(|| Error::ValueNotCallable(name.clone()));
+    async move { callback?.call(args).await }
 }

--- a/src/ext/rustyscript/mod.rs
+++ b/src/ext/rustyscript/mod.rs
@@ -5,6 +5,8 @@ use std::collections::HashMap;
 type FnCache = HashMap<String, Box<dyn RsFunction>>;
 type AsyncFnCache = HashMap<String, Box<dyn RsAsyncFunction>>;
 
+mod callbacks;
+
 #[op2]
 /// Registers a JS function with the runtime as being the entrypoint for the module
 ///

--- a/src/ext/websocket/mod.rs
+++ b/src/ext/websocket/mod.rs
@@ -1,4 +1,3 @@
-use crate::ext::web::Permissions;
 use crate::WebOptions;
 use deno_core::error::AnyError;
 use deno_core::url::Url;
@@ -12,6 +11,7 @@ extension!(
     esm = [ dir "src/ext/websocket", "init_websocket.js" ],
 );
 
+struct Permissions;
 impl WebSocketPermissions for Permissions {
     fn check_net_url(&mut self, _url: &Url, _api_name: &str) -> Result<(), AnyError> {
         Ok(())

--- a/src/ext/websocket/mod.rs
+++ b/src/ext/websocket/mod.rs
@@ -4,19 +4,21 @@ use deno_core::url::Url;
 use deno_core::{extension, Extension};
 use deno_websocket::WebSocketPermissions;
 
-extension!(
-    init_websocket,
-    deps = [rustyscript],
-    esm_entry_point = "ext:init_websocket/init_websocket.js",
-    esm = [ dir "src/ext/websocket", "init_websocket.js" ],
-);
-
+#[derive(Clone, Default)]
 struct Permissions;
 impl WebSocketPermissions for Permissions {
     fn check_net_url(&mut self, _url: &Url, _api_name: &str) -> Result<(), AnyError> {
         Ok(())
     }
 }
+
+extension!(
+    init_websocket,
+    deps = [rustyscript],
+    esm_entry_point = "ext:init_websocket/init_websocket.js",
+    esm = [ dir "src/ext/websocket", "init_websocket.js" ],
+    state = |state| state.put(Permissions::default())
+);
 
 pub fn extensions(options: WebOptions) -> Vec<Extension> {
     vec![

--- a/src/js_value/function.rs
+++ b/src/js_value/function.rs
@@ -31,7 +31,7 @@ impl Function {
         &self,
         runtime: &mut crate::Runtime,
         module_context: Option<&crate::ModuleHandle>,
-        args: &crate::FunctionArguments,
+        args: &impl serde::ser::Serialize,
     ) -> Result<T, crate::Error>
     where
         T: serde::de::DeserializeOwned,
@@ -47,7 +47,7 @@ impl Function {
         &self,
         runtime: &mut crate::Runtime,
         module_context: Option<&crate::ModuleHandle>,
-        args: &crate::FunctionArguments,
+        args: &impl serde::ser::Serialize,
     ) -> Result<T, crate::Error>
     where
         T: serde::de::DeserializeOwned,
@@ -63,7 +63,7 @@ impl Function {
         &self,
         runtime: &mut crate::Runtime,
         module_context: Option<&crate::ModuleHandle>,
-        args: &crate::FunctionArguments,
+        args: &impl serde::ser::Serialize,
     ) -> Result<T, crate::Error>
     where
         T: serde::de::DeserializeOwned,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,7 +288,7 @@ pub use ext::ExtensionOptions;
 
 // Expose some important stuff from us
 pub use error::Error;
-pub use inner_runtime::{FunctionArguments, RsAsyncFunction, RsFunction};
+pub use inner_runtime::{RsAsyncFunction, RsFunction};
 pub use module::{Module, StaticModule};
 pub use module_handle::ModuleHandle;
 pub use module_wrapper::ModuleWrapper;

--- a/src/module_wrapper.rs
+++ b/src/module_wrapper.rs
@@ -125,7 +125,7 @@ impl ModuleWrapper {
     ///
     /// # Returns
     /// A `Result` containing the deserialized result of type `T` on success or an `Error` on failure.
-    pub fn call<T>(&mut self, name: &str, args: &[serde_json::Value]) -> Result<T, Error>
+    pub fn call<T>(&mut self, name: &str, args: &impl serde::ser::Serialize) -> Result<T, Error>
     where
         T: serde::de::DeserializeOwned,
     {
@@ -145,7 +145,7 @@ impl ModuleWrapper {
     pub async fn call_async(
         &mut self,
         name: &str,
-        args: &[serde_json::Value],
+        args: &impl serde::ser::Serialize,
     ) -> Result<serde_json::Value, Error> {
         self.runtime
             .call_function_async(Some(&self.module_context), name, args)
@@ -165,7 +165,7 @@ impl ModuleWrapper {
     pub fn call_immediate(
         &mut self,
         name: &str,
-        args: &[serde_json::Value],
+        args: &impl serde::ser::Serialize,
     ) -> Result<serde_json::Value, Error> {
         self.runtime
             .call_function_immediate(Some(&self.module_context), name, args)
@@ -183,7 +183,7 @@ impl ModuleWrapper {
     pub fn call_stored<T>(
         &mut self,
         function: &Function,
-        args: &[serde_json::Value],
+        args: &impl serde::ser::Serialize,
     ) -> Result<T, Error>
     where
         T: serde::de::DeserializeOwned,
@@ -204,7 +204,7 @@ impl ModuleWrapper {
     pub async fn call_stored_async(
         &mut self,
         function: &Function,
-        args: &[serde_json::Value],
+        args: &impl serde::ser::Serialize,
     ) -> Result<serde_json::Value, Error> {
         self.runtime
             .call_stored_function_async(Some(&self.module_context), function, args)
@@ -224,7 +224,7 @@ impl ModuleWrapper {
     pub fn call_stored_immediate(
         &mut self,
         function: &Function,
-        args: &[serde_json::Value],
+        args: &impl serde::ser::Serialize,
     ) -> Result<serde_json::Value, Error> {
         self.runtime
             .call_stored_function_immediate(Some(&self.module_context), function, args)

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,7 +1,7 @@
 use crate::{
     inner_runtime::{InnerRuntime, InnerRuntimeOptions, RsAsyncFunction, RsFunction},
     js_value::Function,
-    Error, FunctionArguments, Module, ModuleHandle,
+    Error, Module, ModuleHandle,
 };
 use deno_core::serde_json;
 use std::rc::Rc;
@@ -32,10 +32,6 @@ pub struct Runtime {
 }
 
 impl Runtime {
-    /// The lack of any arguments - used to simplify calling functions
-    /// Prevents you from needing to specify the type using ::<serde_json::Value>
-    pub const EMPTY_ARGS: &'static FunctionArguments = &[];
-
     /// Creates a new instance of the runtime with the provided options.
     ///
     /// # Arguments
@@ -186,6 +182,10 @@ impl Runtime {
     /// # Ok(())
     /// # }
     /// ```
+    #[deprecated(
+        since = "0.6.0",
+        note = "No longer needed, pass values and tuples directly"
+    )]
     pub fn into_arg<A>(value: A) -> serde_json::Value
     where
         serde_json::Value: From<A>,
@@ -347,7 +347,7 @@ impl Runtime {
         &mut self,
         module_context: Option<&ModuleHandle>,
         function: &Function,
-        args: &FunctionArguments,
+        args: &impl serde::ser::Serialize,
     ) -> Result<T, Error>
     where
         T: serde::de::DeserializeOwned,
@@ -379,7 +379,7 @@ impl Runtime {
         &mut self,
         module_context: Option<&ModuleHandle>,
         function: &Function,
-        args: &FunctionArguments,
+        args: &impl serde::ser::Serialize,
     ) -> Result<T, Error>
     where
         T: deno_core::serde::de::DeserializeOwned,
@@ -409,7 +409,7 @@ impl Runtime {
         &mut self,
         module_context: Option<&ModuleHandle>,
         function: &Function,
-        args: &FunctionArguments,
+        args: &impl serde::ser::Serialize,
     ) -> Result<T, Error>
     where
         T: deno_core::serde::de::DeserializeOwned,
@@ -446,7 +446,7 @@ impl Runtime {
         &mut self,
         module_context: Option<&ModuleHandle>,
         name: &str,
-        args: &FunctionArguments,
+        args: &impl serde::ser::Serialize,
     ) -> Result<T, Error>
     where
         T: deno_core::serde::de::DeserializeOwned,
@@ -492,7 +492,7 @@ impl Runtime {
         &mut self,
         module_context: Option<&ModuleHandle>,
         name: &str,
-        args: &FunctionArguments,
+        args: &impl serde::ser::Serialize,
     ) -> Result<T, Error>
     where
         T: deno_core::serde::de::DeserializeOwned,
@@ -536,7 +536,7 @@ impl Runtime {
         &mut self,
         module_context: Option<&ModuleHandle>,
         name: &str,
-        args: &FunctionArguments,
+        args: &impl serde::ser::Serialize,
     ) -> Result<T, Error>
     where
         T: deno_core::serde::de::DeserializeOwned,
@@ -802,7 +802,7 @@ impl Runtime {
     pub fn call_entrypoint<T>(
         &mut self,
         module_context: &ModuleHandle,
-        args: &FunctionArguments,
+        args: &impl serde::ser::Serialize,
     ) -> Result<T, Error>
     where
         T: deno_core::serde::de::DeserializeOwned,
@@ -831,7 +831,7 @@ impl Runtime {
     pub async fn call_entrypoint_async<T>(
         &mut self,
         module_context: &ModuleHandle,
-        args: &FunctionArguments,
+        args: &impl serde::ser::Serialize,
     ) -> Result<T, Error>
     where
         T: deno_core::serde::de::DeserializeOwned,
@@ -879,7 +879,7 @@ impl Runtime {
     pub fn call_entrypoint_immediate<T>(
         &mut self,
         module_context: &ModuleHandle,
-        args: &FunctionArguments,
+        args: &impl serde::ser::Serialize,
     ) -> Result<T, Error>
     where
         T: deno_core::serde::de::DeserializeOwned,
@@ -927,7 +927,7 @@ impl Runtime {
         module: &Module,
         side_modules: Vec<&Module>,
         runtime_options: RuntimeOptions,
-        entrypoint_args: &FunctionArguments,
+        entrypoint_args: &impl serde::ser::Serialize,
     ) -> Result<T, Error>
     where
         T: deno_core::serde::de::DeserializeOwned,
@@ -971,6 +971,7 @@ mod test_runtime {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_into_arg() {
         assert_eq!(2, Runtime::into_arg(2));
         assert_eq!("test", Runtime::into_arg("test"));

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -96,8 +96,11 @@ pub fn init_platform(thread_pool_size: u32, idle_task_support: bool) {
 
 #[macro_use]
 mod runtime_macros {
-    /// Map a series of values to a slice of `serde_json::Value` objects
-    /// that javascript functions can understand
+    /// Map a series of values into a form which javascript functions can understand
+    ///
+    /// NOTE: Since 0.6.0, this macro is now effectively a no-op
+    /// It simply builds a tuple reference from the provided arguments
+    ///
     /// # Example
     /// ```rust
     /// use rustyscript::{ Runtime, RuntimeOptions, Module, json_args };
@@ -122,14 +125,8 @@ mod runtime_macros {
     ///
     #[macro_export]
     macro_rules! json_args {
-        ($($arg:expr),+) => {
-            &[
-                $($crate::Runtime::into_arg($arg)),+
-            ]
-        };
-
-        () => {
-            $crate::Runtime::EMPTY_ARGS
+        ($($arg:expr),*) => {
+            &($($arg),*)
         };
     }
 

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -167,7 +167,7 @@ mod runtime_macros {
     macro_rules! big_json_args {
         ($($arg:expr),*) => {
             &vec![
-                $(serde_json::Value::from($arg)),*
+                $($crate::deno_core::serde_json::Value::from($arg)),*
             ]
         };
     }

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -139,11 +139,11 @@ mod runtime_macros {
     ///
     /// Useful if you need more than 16 arguments for a single function call
     /// Warning: This macro is far slower than `json_args!` and should be used sparingly
-    /// Benchmarks place the performance difference at nearly  1,000 times slower!
+    /// Benchmarks place the performance difference at nearly 1,000 times slower!
     ///
     /// # Example
     /// ```rust
-    /// use rustyscript::{ Runtime, RuntimeOptions, Module, json_args };
+    /// use rustyscript::{ Runtime, RuntimeOptions, Module, big_json_args };
     /// use std::time::Duration;
     ///
     /// # fn main() -> Result<(), rustyscript::Error> {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -8,6 +8,7 @@
 //!     let worker = DefaultWorker::new(DefaultWorkerOptions {
 //!         default_entrypoint: None,
 //!         timeout: Duration::from_secs(5),
+//!         ..Default::default()
 //!     })?;
 //!
 //!     let result: i32 = worker.eval("5 + 5".to_string())?;


### PR DESCRIPTION
Arguments used to be encoded as an array ref of `serde_json::Value`, which was inefficient 
Now, function calls accept a single `&impl Serialize` argument, which is decoded directly by v8

The old macro is left in place for compatibility, and a new `big_json_args` is now available that uses the old method to bypass serde's 16 arg tuple limit.