### PR TITLE
Fix global export of EventSource in deno_fetch extension

### DIFF
--- a/examples/web_features.rs
+++ b/examples/web_features.rs
@@ -33,6 +33,18 @@ fn main() -> Result<(), Error> {
                   .catch(e => reject(e));
             });
         }
+
+        export async function event_source_example() {
+            return new Promise((accept, reject) => {
+                var source = new EventSource('https://www.w3schools.com/html/demo_sse.php');
+                source.addEventListener('message', (e) => {
+                    accept(e.data);
+                });
+                source.addEventListener('error', (e) => {
+                  reject(e)
+                });
+            });
+        }
         ",
     );
 
@@ -52,5 +64,11 @@ fn main() -> Result<(), Error> {
     let data: rustyscript::serde_json::Value =
         runtime.call_function(Some(&module_handle), "fetch_example", json_args!())?;
     println!("Got {:?} bytes", data.to_string().len());
+
+    // EventSource example
+    let data: rustyscript::serde_json::Value =
+        runtime.call_function(Some(&module_handle), "event_source_example", json_args!())?;
+    println!("Got event: {}", data);
+
     Ok(())
 }

--- a/src/ext/web/init_fetch.js
+++ b/src/ext/web/init_fetch.js
@@ -7,11 +7,13 @@ import * as eventSource from "ext:deno_fetch/27_eventsource.js";
 
 Deno.core.setWasmStreamingCallback(fetch.handleWasmStreaming);
 
-import { applyToGlobal, writeable, nonEnumerable } from 'ext:rustyscript/rustyscript.js';
+import {applyToGlobal, writeable, nonEnumerable} from 'ext:rustyscript/rustyscript.js';
+
 applyToGlobal({
     fetch: writeable(fetch.fetch),
     Request: nonEnumerable(request.Request),
     Response: nonEnumerable(response.Response),
     Headers: nonEnumerable(headers.Headers),
     FormData: nonEnumerable(formData.FormData),
+    EventSource: nonEnumerable(eventSource.EventSource)
 });


### PR DESCRIPTION
This PR fixes the missing export of the Web API class `EventSource` to the global scope, and also add an example of the usage to `web_features.rs` example.

Link to the mdn docs:
https://developer.mozilla.org/en-US/docs/Web/API/EventSource