### PR TITLE
Add config option for whitelisting custom schemas

### DIFF
--- a/examples/example_extension/example_extension.js
+++ b/examples/example_extension/example_extension.js
@@ -1,8 +1,6 @@
 /**
  * This file is the JS component used in the runtime_extensions example
- * It adds an object to the global scope which can call the OPs configured
- * for the extension
+ * It exports a function that calls the op_add_example Rust function
  */
-globalThis.example_ext = {
-    'add': (a, b) => Deno.core.ops.op_add_example(a, b)
-};
+
+export const add = (a, b) => Deno.core.ops.op_add_example(a, b);

--- a/examples/example_extension/mod.rs
+++ b/examples/example_extension/mod.rs
@@ -20,6 +20,6 @@ fn op_add_example(#[bigint] a: i64, #[bigint] b: i64) -> i64 {
 extension!(
     example_extension,
     ops = [op_add_example],
-    esm_entry_point = "ext:example_extension/example_extension.js",
-    esm = [ dir "examples/example_extension", "example_extension.js" ],
+    esm_entry_point = "example:calculator",
+    esm = [ dir "examples/example_extension", "example:calculator" = "example_extension.js" ],
 );

--- a/examples/runtime_extensions.rs
+++ b/examples/runtime_extensions.rs
@@ -8,16 +8,28 @@
 /// and one or more optional JS modules.
 ///
 use rustyscript::{Error, Module, Runtime, RuntimeOptions};
+use std::collections::HashSet;
 
 mod example_extension;
 
 fn main() -> Result<(), Error> {
-    let module = Module::new("test.js", " export const result = example_ext.add(5, 5); ");
+    let module = Module::new(
+        "test.js",
+        r#"
+        import { add } from "example:calculator";
+        export const result = add(5, 5);
+    "#,
+    );
+
+    // Whitelist the example: schema for the module
+    let mut schema_whlist = HashSet::new();
+    schema_whlist.insert("example:".to_string());
 
     // We provide a function returning the set of extensions to load
     // It needs to be a function, since deno_core does not currently
     // allow clone or copy from extensions
     let mut runtime = Runtime::new(RuntimeOptions {
+        schema_whlist,
         extensions: vec![example_extension::example_extension::init_ops_and_esm()],
         ..Default::default()
     })?;
@@ -25,5 +37,6 @@ fn main() -> Result<(), Error> {
 
     let result: i64 = runtime.get_value(Some(&module_handle), "result")?;
     assert_eq!(10, result);
+
     Ok(())
 }

--- a/src/inner_runtime.rs
+++ b/src/inner_runtime.rs
@@ -7,7 +7,12 @@ use crate::{
 };
 use deno_core::{serde_json, serde_v8::from_v8, v8, JsRuntime, PollEventLoopOptions};
 use serde::de::DeserializeOwned;
-use std::{collections::HashMap, pin::Pin, rc::Rc, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    pin::Pin,
+    rc::Rc,
+    time::Duration,
+};
 
 /// Represents a function that can be registered with the runtime
 pub trait RsFunction:
@@ -105,6 +110,9 @@ pub struct RuntimeOptions {
     /// Optional shared array buffer store to use for the runtime
     /// Allows data-sharing between runtimes across threads
     pub shared_array_buffer_store: Option<deno_core::SharedArrayBufferStore>,
+
+    /// A whitelist of custom schema prefixes that are allowed to be loaded
+    pub schema_whlist: HashSet<String>,
 }
 
 impl Default for RuntimeOptions {
@@ -118,6 +126,7 @@ impl Default for RuntimeOptions {
             startup_snapshot: None,
             isolate_params: None,
             shared_array_buffer_store: None,
+            schema_whlist: HashSet::default(),
 
             extension_options: ExtensionOptions::default(),
         }
@@ -141,6 +150,7 @@ impl InnerRuntime {
         let module_loader = Rc::new(RustyLoader::new(LoaderOptions {
             cache_provider: options.module_cache,
             import_provider: options.import_provider,
+            schema_whlist: options.schema_whlist,
 
             ..Default::default()
         }));

--- a/src/module_loader/inner_loader.rs
+++ b/src/module_loader/inner_loader.rs
@@ -33,6 +33,9 @@ pub struct LoaderOptions {
 
     /// An optional import provider to manage module resolution
     pub import_provider: Option<Box<dyn ImportProvider>>,
+
+    /// A whitelist of custom schema prefixes that are allowed to be loaded
+    pub schema_whlist: HashSet<String>,
 }
 
 /// Internal implementation of the module loader
@@ -45,6 +48,7 @@ pub struct InnerRustyLoader {
     fs_whlist: HashSet<String>,
     source_map_cache: SourceMapCache,
     import_provider: Option<Box<dyn ImportProvider>>,
+    schema_whlist: HashSet<String>,
 }
 
 impl InnerRustyLoader {
@@ -56,6 +60,7 @@ impl InnerRustyLoader {
             fs_whlist: options.fs_whitelist,
             source_map_cache: options.source_map_cache,
             import_provider: options.import_provider,
+            schema_whlist: options.schema_whlist,
         }
     }
 
@@ -124,6 +129,10 @@ impl InnerRustyLoader {
 
             _ if specifier.starts_with("ext:") => {
                 // Extension import - allow
+            }
+
+            _ if self.schema_whlist.iter().any(|s| specifier.starts_with(s)) => {
+                // Custom schema whitelist import - allow
             }
 
             _ => {


### PR DESCRIPTION
Hello,

Thanks for this crate. Great to see such a feature-complete implementation!

I'm porting my code from my bespoke/spaghetti `deno_core` runtime over to this crate and have hit a snag WRT to loader permissions.

Using regular `deno_core` I was able to define extensions like the following:

```rust
extension!(
    sessions_ext,
    ops = [op_get_current_identity],
    esm_entry_point = "proven:sessions",
    esm = [ dir "src/extensions", "proven:sessions" = "sessions.js" ],
);
```

These extensions could then be used inside user-provided runtime code like:

```js
import { getCurrentIdentity } from "proven:sessions";
```

However, in `rustyscript` the `InnerLoader` permissions checker will error with `Error: Runtime("unrecognized schema for module import: proven:sessions")` unless the module begins with `ext:`. 

Switching the extension to use `ext:sessions` also results in `deno_core` [correctly] throwing `Error: Runtime("Importing ext: modules is only allowed from ext: and node: modules.")`.

This pull request creates an additional runtime option which allows such custom schemas to be whitelisted. Allowing for a similar setup to `deno_core`. E.g.

```rust
let mut schema_whlist = HashSet::new();
schema_whlist.insert("proven:".to_string());
let mut runtime = Runtime::new(RuntimeOptions {
    schema_whlist,
    extensions: vec![sessions_ext::init_ops_and_esm()],
    ..Default::default()
})?;
```

Thanks again!