### PR TITLE
Add max_heap_size option and related error variant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2992,6 +2992,7 @@ dependencies = [
  "serde",
  "thiserror",
  "tokio",
+ "tokio-util",
  "version-sync",
  "winapi",
 ]
@@ -3892,9 +3893,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ deno_ast = { version = "0.41.2", features = ["transpiling"]}
 
 # Runtime for async tasks
 tokio = "1.39.2"
+tokio-util = "0.7.12"
 
 # For URL imports
 # Pinned for now due to upstream issues

--- a/examples/max_heap_size.rs
+++ b/examples/max_heap_size.rs
@@ -1,0 +1,26 @@
+///
+/// This example shows how to set the maximum heap size for the V8 isolate.
+/// This is useful when you want to limit the amount of memory a script can consume.
+/// A `HeapExhausted` error will be returned if the script exceeds the limit.
+///
+use rustyscript::{Error, Module, Runtime, RuntimeOptions};
+
+fn main() -> Result<(), Error> {
+    // Will exceed the defined heap size
+    let module = Module::new(
+        "test.js",
+        "const largeArray = new Array(40 * 1024 * 1024).fill('a');",
+    );
+
+    let mut runtime = Runtime::new(RuntimeOptions {
+        max_heap_size: Some(5 * 1024 * 1024),
+        ..Default::default()
+    })?;
+
+    // Will return a `HeapExhausted` error
+    let module_handle = runtime.load_module(&module);
+
+    assert!(module_handle.is_err());
+
+    Ok(())
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -70,6 +70,10 @@ pub enum Error {
     /// Triggers when a module times out before finishing
     #[error("Module timed out: {0}")]
     Timeout(String),
+
+    /// Triggers when the heap (via `max_heap_size`) is exhausted during execution
+    #[error("Heap exhausted")]
+    HeapExhausted,
 }
 
 impl Error {


### PR DESCRIPTION
For your consideration: this PR adds a new `max_heap_size` option to RuntimeOptions. Merging the provided setting into any existing `isolate_options` if given.

Using a `CancellationToken` to sync the termination across both inner and outer runtime, as just terminating the isolate leaves tokio hanging... needed to modify the on_block call to abort its inner future also.

LMK if you think it's useful, or if there's a better way to go about it.