### PR TITLE
Update reqwest to =0.12.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,7 @@ hyper-util = {version = "=0.1.7", optional = true}
 
 # For URL imports
 # Pinned for now due to upstream issues
-reqwest = { version = "=0.12.8", optional = true, default-features = false, features = ["blocking", "rustls-tls"] }
+reqwest = { version = "=0.12.12", optional = true, default-features = false, features = ["blocking", "rustls-tls"] }
 http = { version = "1.0", optional = true }
 deno_permissions = { version = "0.40.0", optional = true }
 


### PR DESCRIPTION
As stated by the PR title. Do upstream issues still exist that require hard-pinning this dependency?