### PR TITLE
match deno@2.3.3 dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.87"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -411,20 +411,11 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64-simd"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "781dd20c3aff0bd194fe7d2a977dd92f21c173891f3a03b677359e5fa457e5d5"
-dependencies = [
- "simd-abstraction",
-]
-
-[[package]]
-name = "base64-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
 dependencies = [
- "outref 0.5.1",
+ "outref",
  "vsimd",
 ]
 
@@ -454,29 +445,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
+version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags 2.9.0",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.87",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
  "bitflags 2.9.0",
  "cexpr",
@@ -487,18 +458,9 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash 2.1.1",
  "shlex",
  "syn 2.0.87",
-]
-
-[[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec 0.6.3",
 ]
 
 [[package]]
@@ -507,14 +469,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec",
 ]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -678,15 +634,6 @@ checksum = "1bf2a5fb3207c12b5d208ebc145f967fea5cac41a021c37417ccc31ba40f39ee"
 
 [[package]]
 name = "capacity_builder"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ec49028cb308564429cd8fac4ef21290067a0afe8f5955330a8d487d0d790c"
-dependencies = [
- "itoa",
-]
-
-[[package]]
-name = "capacity_builder"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f2d24a6dcf0cd402a21b65d35340f3a49ff3475dc5fdac91d22d2733e6641c6"
@@ -733,12 +680,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.6"
+version = "1.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
+checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -1256,20 +1204,19 @@ dependencies = [
 
 [[package]]
 name = "deno_ast"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd3b6e14e5b1235dd613d9f5d955d7a80dec6de0fc00fa34b5d0ef5ca0a9ddb"
+checksum = "59d2c5dcead329b1382472f0ca026839f33a86d897b47cf6d9cfa21c520b69c6"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
+ "capacity_builder",
  "deno_error",
  "deno_media_type",
  "deno_terminal",
  "dprint-swc-ext",
- "once_cell",
  "percent-encoding",
  "serde",
- "sourcemap 9.0.0",
- "string_capacity",
+ "sourcemap",
  "swc_atoms",
  "swc_common",
  "swc_config",
@@ -1292,34 +1239,35 @@ dependencies = [
  "swc_visit",
  "swc_visit_macros",
  "text_lines",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "unicode-width 0.2.0",
  "url",
 ]
 
 [[package]]
 name = "deno_broadcast_channel"
-version = "0.188.0"
+version = "0.199.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f9af9df689f5a2b5b6e69588da8983c5cfbd180821b7a5379e218368c782c39"
+checksum = "4e47997aae2d20622f7c6906c2d6682a45b0807b6932928b9c9d91fe8744c6c1"
 dependencies = [
  "async-trait",
  "deno_core",
  "deno_error",
- "thiserror 2.0.4",
+ "deno_features",
+ "thiserror 2.0.12",
  "tokio",
  "uuid",
 ]
 
 [[package]]
 name = "deno_cache"
-version = "0.126.0"
+version = "0.137.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "661ad6e65eb2b377d6499b9a92c396d4af4cd14a5d463973e86b52d0b4ad861d"
+checksum = "8ef0955e60153b9f863d82956e94dd34a55cb28a4693ccd0c9103da094d425b2"
 dependencies = [
  "async-stream",
  "async-trait",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "deno_core",
@@ -1335,16 +1283,16 @@ dependencies = [
  "serde",
  "sha2",
  "slab",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-util",
 ]
 
 [[package]]
 name = "deno_cache_dir"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cadb05700726eb97cb4914d8016ff81ece094b1c3ed442d6f48f297961a5a96"
+checksum = "869a62459ded73382e018c7c58a07df170ba5f5befb67e18ee10494e769efe2a"
 dependencies = [
  "async-trait",
  "base32",
@@ -1357,7 +1305,7 @@ dependencies = [
  "deno_media_type",
  "deno_path_util",
  "http 1.1.0",
- "indexmap 2.6.0",
+ "indexmap 2.9.0",
  "log",
  "once_cell",
  "parking_lot",
@@ -1371,9 +1319,9 @@ dependencies = [
 
 [[package]]
 name = "deno_canvas"
-version = "0.63.0"
+version = "0.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "103964df6d693c3605839b6819c1deb281218219fd6282ecfc79b0c10a787ed9"
+checksum = "293ca44d7b647d50337f517cac34f5c658a719a1d9be570d2bfc779c30823aec"
 dependencies = [
  "bytemuck",
  "deno_core",
@@ -1381,17 +1329,17 @@ dependencies = [
  "image",
  "lcms2",
  "num-traits",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "deno_config"
-version = "0.50.0"
+version = "0.54.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56792005d20f0b38f2e190b15918362440bebc0065b825af59d6022be465f764"
+checksum = "35a3ff33a35a2e995bfea372cbe9fe0990a735e27988a787277a1c6ee15d1b1a"
 dependencies = [
  "boxed_error",
- "capacity_builder 0.5.0",
+ "capacity_builder",
  "deno_error",
  "deno_package_json",
  "deno_path_util",
@@ -1399,7 +1347,7 @@ dependencies = [
  "glob",
  "ignore",
  "import_map",
- "indexmap 2.6.0",
+ "indexmap 2.9.0",
  "jsonc-parser",
  "log",
  "percent-encoding",
@@ -1407,32 +1355,32 @@ dependencies = [
  "serde",
  "serde_json",
  "sys_traits",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "url",
 ]
 
 [[package]]
 name = "deno_console"
-version = "0.194.0"
+version = "0.205.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b4d739c2e015d3aae978afb749eda60f0d5c4b5a89059478aeb3b51cf65199d"
+checksum = "f18e4a73bc0dd2a30dfbc14d8c2eb9b7347b7616acb6810d71e7912385c34f89"
 dependencies = [
  "deno_core",
 ]
 
 [[package]]
 name = "deno_core"
-version = "0.340.0"
+version = "0.347.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe2827cc1215963b5073cca7db7c0ed8d8717a40e5ebad20832ae70e6df2d9d1"
+checksum = "d75ae5562f6ad750bc2007e7b1032ae37115a83fe58b6fbc77331c47744956cc"
 dependencies = [
  "anyhow",
  "az",
  "bincode",
- "bit-set 0.5.3",
- "bit-vec 0.6.3",
+ "bit-set",
+ "bit-vec",
  "bytes",
- "capacity_builder 0.1.3",
+ "capacity_builder",
  "cooked-waker",
  "deno_core_icudata",
  "deno_error",
@@ -1440,9 +1388,8 @@ dependencies = [
  "deno_path_util",
  "deno_unsync",
  "futures",
- "indexmap 2.6.0",
+ "indexmap 2.9.0",
  "libc",
- "memoffset",
  "parking_lot",
  "percent-encoding",
  "pin-project",
@@ -1450,9 +1397,9 @@ dependencies = [
  "serde_json",
  "serde_v8",
  "smallvec",
- "sourcemap 8.0.1",
+ "sourcemap",
  "static_assertions",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "tokio",
  "url",
  "v8",
@@ -1467,29 +1414,30 @@ checksum = "fe4dccb6147bb3f3ba0c7a48e993bfeb999d2c2e47a81badee80e2b370c8d695"
 
 [[package]]
 name = "deno_cron"
-version = "0.74.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36fdcf306889d99778ff451113ee8985276828164b72a15c7c5102b9ebe40f67"
+checksum = "fa710e70d29c6951f865e677cf0a080caa2b838b70d1847a43b1cfc52b622db0"
 dependencies = [
  "async-trait",
  "chrono",
  "deno_core",
  "deno_error",
+ "deno_features",
  "saffron",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "tokio",
 ]
 
 [[package]]
 name = "deno_crypto"
-version = "0.208.0"
+version = "0.219.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9738549e14dacbd0a92d3a6488cb9432510f6cd829f136b0330d332308d716"
+checksum = "7608cfcd00abfe7452930b8480afdb3fa5fe28dbbafa4463b083b8322243fefe"
 dependencies = [
  "aes",
  "aes-gcm",
  "aes-kw",
- "base64 0.21.7",
+ "base64 0.22.1",
  "cbc",
  "const-oid",
  "ctr",
@@ -1497,6 +1445,7 @@ dependencies = [
  "deno_core",
  "deno_error",
  "deno_web",
+ "ecdsa",
  "ed448-goldilocks",
  "elliptic-curve",
  "num-traits",
@@ -1511,8 +1460,9 @@ dependencies = [
  "serde_bytes",
  "sha1",
  "sha2",
+ "signature",
  "spki",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "tokio",
  "uuid",
  "x25519-dalek",
@@ -1520,9 +1470,9 @@ dependencies = [
 
 [[package]]
 name = "deno_error"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c23dbc46d5804814b08b4675838f9884e3a52916987ec5105af36d42f9911b5"
+checksum = "19fae9fe305307b5ef3ee4e8244c79cffcca421ab0ce8634dea0c6b1342f220f"
 dependencies = [
  "deno_error_macro",
  "libc",
@@ -1534,9 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "deno_error_macro"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "babccedee31ce7e57c3e6dff2cb3ab8d68c49d0df8222fe0d11d628e65192790"
+checksum = "5abb2556e91848b66f562451fcbcdee2a3b7c88281828908dcf7cca355f5d997"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1544,12 +1494,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "deno_fetch"
-version = "0.218.0"
+name = "deno_features"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da6cc139b1379d4f083fe5f4bd501dc14cc203313ffec62c5d305f7a9bc0ae0d"
+checksum = "cf0bffbb52e0ad53c50225cdf0c20b24501036c3948264a049487fc5e5c40f57"
 dependencies = [
- "base64 0.21.7",
+ "deno_core",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "deno_fetch"
+version = "0.229.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "169ba4dc4ece5de4994dc9c5fdd30f7a2e019313eaf9911aa8db0919fe9e6495"
+dependencies = [
+ "base64 0.22.1",
  "bytes",
  "data-url",
  "deno_core",
@@ -1572,7 +1533,7 @@ dependencies = [
  "rustls-webpki",
  "serde",
  "serde_json",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-rustls",
  "tokio-socks",
@@ -1584,15 +1545,16 @@ dependencies = [
 
 [[package]]
 name = "deno_ffi"
-version = "0.181.0"
+version = "0.192.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56413d640ea5d9e71cd55a6b3783c2f38c4ca604f2349b46f6082745a656ea98"
+checksum = "d9836a034424a050372548a34dd4f4305aa2e677980e9c3b4be7e49161dcefba"
 dependencies = [
  "cranelift",
  "cranelift-native",
  "deno_core",
  "deno_error",
  "deno_permissions",
+ "denort_helper",
  "dlopen2",
  "libffi",
  "libffi-sys",
@@ -1602,16 +1564,16 @@ dependencies = [
  "serde",
  "serde-value",
  "serde_json",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "tokio",
  "winapi",
 ]
 
 [[package]]
 name = "deno_fs"
-version = "0.104.0"
+version = "0.115.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061d905357c573502d58025e0f631353504c2742e3a21acd90977c5253e28a62"
+checksum = "df413f816b1cfd10a0cd67da0aa0ad421bb4b45610da362202c004a39f61416b"
 dependencies = [
  "async-trait",
  "base32",
@@ -1624,24 +1586,24 @@ dependencies = [
  "filetime",
  "junction",
  "libc",
- "nix",
+ "nix 0.27.1",
  "rand 0.8.5",
  "rayon",
  "serde",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "winapi",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "deno_http"
-version = "0.192.0"
+version = "0.203.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d94f9932108a90725f9c13f1107c6a11ca1b5e77d169c8a878b36a3d20c4f0f6"
+checksum = "318310b221f1da7ff04b959b79001fcfd56ad329e9a44fe3c86b27378b5785eb"
 dependencies = [
  "async-compression",
  "async-trait",
- "base64 0.21.7",
+ "base64 0.22.1",
  "brotli",
  "bytes",
  "cache_control",
@@ -1657,8 +1619,9 @@ dependencies = [
  "hyper 0.14.31",
  "hyper 1.6.0",
  "hyper-util",
- "itertools 0.10.5",
- "memmem",
+ "itertools 0.14.0",
+ "log",
+ "memchr",
  "mime",
  "once_cell",
  "percent-encoding",
@@ -1668,16 +1631,16 @@ dependencies = [
  "scopeguard",
  "serde",
  "smallvec",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-util",
 ]
 
 [[package]]
 name = "deno_io"
-version = "0.104.0"
+version = "0.115.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f70e967125c9d5efcc93c66e55466b6fce86da4ada9241cc0d9c254e56311f"
+checksum = "a4ab5157e8769632476045608317617a96cef09d0fde6b123262bbc038f2f5c1"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -1699,18 +1662,19 @@ dependencies = [
 
 [[package]]
 name = "deno_kv"
-version = "0.102.0"
+version = "0.113.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8016aa769642596421ac8f7337d3ebd0b6b34c4746605bc40c0275b2f12cdc8"
+checksum = "bcee10c3519a52278a6650300c01e6815ddb63167438417ecd5bf1ff9521d413"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.21.7",
+ "base64 0.22.1",
  "boxed_error",
  "bytes",
  "chrono",
  "deno_core",
  "deno_error",
+ "deno_features",
  "deno_fetch",
  "deno_path_util",
  "deno_permissions",
@@ -1726,27 +1690,28 @@ dependencies = [
  "rand 0.8.5",
  "rusqlite",
  "serde",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "url",
 ]
 
 [[package]]
 name = "deno_lockfile"
-version = "0.24.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632e835a53ed667d62fdd766c5780fe8361c831d3e3fbf1a760a0b7896657587"
+checksum = "a7a03d93aa789e2652a644e3e71638b4e21faafad5f7392dc8f126589d158695"
 dependencies = [
+ "async-trait",
  "deno_semver",
  "serde",
  "serde_json",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "deno_media_type"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "480223262efd08f96b3be5f0457c82bac7296e70dc4e7ef7350751f66293812c"
+checksum = "3d9080fcfcea53bcd6eea1916217bd5611c896f3a0db4c001a859722a1258a47"
 dependencies = [
  "data-url",
  "serde",
@@ -1755,18 +1720,19 @@ dependencies = [
 
 [[package]]
 name = "deno_napi"
-version = "0.125.0"
+version = "0.136.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae3dc9ca5e004bd2689f9fa009582f5a30726410b3aafe690f6f320aa0edcad"
+checksum = "3140183d12f71f72698a42c9e2a8236ed6a49442352cc15e2801aed8b4253c32"
 dependencies = [
  "deno_core",
  "deno_error",
  "deno_permissions",
+ "denort_helper",
  "libc",
  "libloading 0.7.4",
  "log",
  "napi_sym",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "windows-sys 0.59.0",
 ]
 
@@ -1785,12 +1751,13 @@ dependencies = [
 
 [[package]]
 name = "deno_net"
-version = "0.186.0"
+version = "0.197.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad24f8af5799aac5a2d246a93e5e0e1edd6f15e89f577ac6d92e074ca26d975"
+checksum = "6291f993f09b403f873c7426fbf47a2c06a56cbc7c226fe02b03775be16ce805"
 dependencies = [
  "deno_core",
  "deno_error",
+ "deno_features",
  "deno_permissions",
  "deno_tls",
  "hickory-proto",
@@ -1801,21 +1768,22 @@ dependencies = [
  "serde",
  "sha2",
  "socket2",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "tokio",
+ "tokio-vsock",
  "url",
  "web-transport-proto",
 ]
 
 [[package]]
 name = "deno_node"
-version = "0.132.0"
+version = "0.143.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb91293a833b8d0da8f2f0143e08139f3d9de4220a0ffb6dddd057c5d86020b0"
+checksum = "1db9fe4769c2d64dd0f43e8c167606f06d5de0aded7714b89f2f378b11608089"
 dependencies = [
  "aead-gcm-stream",
  "aes",
- "base64 0.21.7",
+ "base64 0.22.1",
  "blake2",
  "boxed_error",
  "brotli",
@@ -1837,6 +1805,7 @@ dependencies = [
  "deno_whoami",
  "der",
  "digest",
+ "dotenvy",
  "dsa",
  "ecb",
  "ecdsa",
@@ -1854,7 +1823,6 @@ dependencies = [
  "ipnetwork",
  "k256",
  "libc",
- "libsqlite3-sys",
  "libz-sys",
  "md-5",
  "md4",
@@ -1884,9 +1852,10 @@ dependencies = [
  "sm3",
  "spki",
  "sys_traits",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-eld",
+ "tower-service",
  "url",
  "webpki-root-certs",
  "winapi",
@@ -1898,46 +1867,47 @@ dependencies = [
 
 [[package]]
 name = "deno_npm"
-version = "0.27.2"
+version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4adceb4c34f10e837d0e3ae76e88dddefb13e83c05c1ef1699fa5519241c9d27"
+checksum = "c9cf5aab0fbd2e68c022fef8981a92c4e4b0fcec341c08af1ebb3651f03cd86b"
 dependencies = [
  "async-trait",
- "capacity_builder 0.5.0",
+ "capacity_builder",
  "deno_error",
  "deno_lockfile",
  "deno_semver",
  "futures",
+ "indexmap 2.9.0",
  "log",
  "monch",
  "serde",
  "serde_json",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "url",
 ]
 
 [[package]]
 name = "deno_ops"
-version = "0.216.0"
+version = "0.223.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07cc2bc8f1754c7f66b701a05fb12ca39dc582edf8b4f04a422ae487f0223fa9"
+checksum = "c5adc7f0795c7547f1b560a07aaea484e8f9cd035318348c6bfd084e0c42dce8"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap 2.9.0",
  "proc-macro-rules",
  "proc-macro2",
  "quote",
  "stringcase",
- "strum 0.25.0",
- "strum_macros 0.25.3",
+ "strum 0.27.1",
+ "strum_macros 0.27.1",
  "syn 2.0.87",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "deno_os"
-version = "0.11.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020802e89e17addcf53c75b15c0e9f3d343976cae25ee3a74d2d725ba92ea189"
+checksum = "572571939a1c267dc48b20d128e22e2917f778a9657b9e600e3358936322be08"
 dependencies = [
  "deno_core",
  "deno_error",
@@ -1951,26 +1921,26 @@ dependencies = [
  "serde",
  "signal-hook",
  "signal-hook-registry",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "tokio",
  "winapi",
 ]
 
 [[package]]
 name = "deno_package_json"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb8582ef20e0c5ed9bc43e93f593a461b63bd106311117feb3baf9ce8ea03d95"
+checksum = "236bc2d6d6c06b68cbde960542e13501cf833c975f221a012da619f714c57123"
 dependencies = [
  "boxed_error",
  "deno_error",
  "deno_path_util",
  "deno_semver",
- "indexmap 2.6.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_json",
  "sys_traits",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "url",
 ]
 
@@ -1983,17 +1953,17 @@ dependencies = [
  "deno_error",
  "percent-encoding",
  "sys_traits",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "url",
 ]
 
 [[package]]
 name = "deno_permissions"
-version = "0.53.0"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040545b3e7e1dbd5fe56e7cfc41717c4d594af956a4807eb2fe65af91d60dd0"
+checksum = "501f5bb2f44b977eb682c42909df35b980edf5144d3b5f00796e96a67df0055c"
 dependencies = [
- "capacity_builder 0.5.0",
+ "capacity_builder",
  "deno_core",
  "deno_error",
  "deno_path_util",
@@ -2004,16 +1974,16 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "serde",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "which",
  "winapi",
 ]
 
 [[package]]
 name = "deno_process"
-version = "0.9.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e983395abc895f7537ddd471a85497bc2585eddab14a7d79a2f90d8d5f40747b"
+checksum = "cce5d661da16ef5d52a218231037344f43fcbe7c02cd7243f9296d3ae4127351"
 dependencies = [
  "deno_core",
  "deno_error",
@@ -2025,13 +1995,13 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix",
+ "nix 0.27.1",
  "pin-project-lite",
  "rand 0.8.5",
  "serde",
  "simd-json",
  "tempfile",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "tokio",
  "which",
  "winapi",
@@ -2040,9 +2010,9 @@ dependencies = [
 
 [[package]]
 name = "deno_resolver"
-version = "0.25.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256bd6db0f0da8b0aeb1c7469ab54c71473f9bf17208b81e4b9e4d57384f876a"
+checksum = "80ef70c20f52ff0461f5558738afed7fd360b664bc641788c8a48a76562660f4"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -2059,9 +2029,10 @@ dependencies = [
  "deno_path_util",
  "deno_semver",
  "deno_terminal",
+ "deno_unsync",
  "futures",
  "import_map",
- "indexmap 2.6.0",
+ "indexmap 2.9.0",
  "log",
  "node_resolver",
  "once_cell",
@@ -2069,15 +2040,15 @@ dependencies = [
  "serde",
  "serde_json",
  "sys_traits",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "url",
 ]
 
 [[package]]
 name = "deno_runtime"
-version = "0.202.0"
+version = "0.213.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90623f6d1844b094637af04e9b7115821ed47a30db588a5d3a01c29312ab07af"
+checksum = "bee2725c7610460a10b771ea5fecece28bf9e56f7c87b44d9fda4992490afeb5"
 dependencies = [
  "color-print",
  "deno_broadcast_channel",
@@ -2088,6 +2059,7 @@ dependencies = [
  "deno_cron",
  "deno_crypto",
  "deno_error",
+ "deno_features",
  "deno_fetch",
  "deno_ffi",
  "deno_fs",
@@ -2119,7 +2091,7 @@ dependencies = [
  "hyper-util",
  "libc",
  "log",
- "nix",
+ "nix 0.27.1",
  "node_resolver",
  "notify",
  "ntapi",
@@ -2128,7 +2100,7 @@ dependencies = [
  "same-file",
  "serde",
  "sys_traits",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-metrics",
  "twox-hash",
@@ -2143,22 +2115,22 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4775271f9b5602482698f76d24ea9ed8ba27af7f587a7e9a876916300c542435"
 dependencies = [
- "capacity_builder 0.5.0",
+ "capacity_builder",
  "deno_error",
  "ecow",
  "hipstr",
  "monch",
  "once_cell",
  "serde",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "url",
 ]
 
 [[package]]
 name = "deno_telemetry"
-version = "0.16.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d029c57a0c3034ba685c248c547382daeed2b554b57c4244e95ff14f995c729"
+checksum = "c178ae71033b1086b35b4a256a31e8c331623956a79f2177d6b35d6a656cce88"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -2177,15 +2149,15 @@ dependencies = [
  "opentelemetry_sdk",
  "pin-project",
  "serde",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "tokio",
 ]
 
 [[package]]
 name = "deno_terminal"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daef12499e89ee99e51ad6000a91f600d3937fb028ad4918af76810c5bc9e0d5"
+checksum = "23f71c27009e0141dedd315f1dfa3ebb0a6ca4acce7c080fac576ea415a465f6"
 dependencies = [
  "once_cell",
  "termcolor",
@@ -2193,9 +2165,9 @@ dependencies = [
 
 [[package]]
 name = "deno_tls"
-version = "0.181.0"
+version = "0.192.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3005fe45eb235a586fafe1548a4bb2643b296243c6e293fac9bcd687f70fa2f2"
+checksum = "423a3b90429be302bbcccbea6ca6a539c0d2f97a54e132458c41004ea2ad20d1"
 dependencies = [
  "deno_core",
  "deno_error",
@@ -2205,7 +2177,7 @@ dependencies = [
  "rustls-tokio-stream",
  "rustls-webpki",
  "serde",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "tokio",
  "webpki-roots",
 ]
@@ -2223,9 +2195,9 @@ dependencies = [
 
 [[package]]
 name = "deno_url"
-version = "0.194.0"
+version = "0.205.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7984329d2985f748308047f3b888fd4bc32f493eb686bd931e9e8c4b377c5a8"
+checksum = "af2813696e113b21c288558151c86a0f60d1afda3458bc76e5d29173fe288c22"
 dependencies = [
  "deno_core",
  "deno_error",
@@ -2234,12 +2206,12 @@ dependencies = [
 
 [[package]]
 name = "deno_web"
-version = "0.225.0"
+version = "0.236.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001d86a715d552cbb84d1b714a1eeb23aaaf0043b2fbd31ee387aefa89e92b3b"
+checksum = "8b0885564bfade3284b26a29cb32a67ba7b75fe329b7f12bc0e26815acf7ae1c"
 dependencies = [
  "async-trait",
- "base64-simd 0.8.0",
+ "base64-simd",
  "bytes",
  "deno_core",
  "deno_error",
@@ -2248,25 +2220,25 @@ dependencies = [
  "flate2",
  "futures",
  "serde",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "tokio",
  "uuid",
 ]
 
 [[package]]
 name = "deno_webgpu"
-version = "0.161.0"
+version = "0.172.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f708367f91749e7714c72cadfb46713c712cb97bf5aa4b505772dd28591b7bcb"
+checksum = "a2b7cc8f70ea5508386468108310c90d7baf251b90dfff76f22474eac7d0ed2f"
 dependencies = [
  "deno_core",
  "deno_error",
  "deno_unsync",
- "indexmap 2.6.0",
+ "indexmap 2.9.0",
  "raw-window-handle",
  "serde",
  "serde_json",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "tokio",
  "wgpu-core",
  "wgpu-types",
@@ -2274,18 +2246,18 @@ dependencies = [
 
 [[package]]
 name = "deno_webidl"
-version = "0.194.0"
+version = "0.205.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b59c05afdc635ca2a2854d780564b277ddc823738c4ead16dbead2172e1aa8f7"
+checksum = "7e4f3a7a4672a071d25e93b5598f4a8a4bfc20f2a8d6900a7a6a7d02264bc6f2"
 dependencies = [
  "deno_core",
 ]
 
 [[package]]
 name = "deno_websocket"
-version = "0.199.0"
+version = "0.210.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2231c32eb6c30c02b1d54c5c757ee4383ae7798f35086597add7a7ccac259f"
+checksum = "70452e61dd4e7c157aedb14e0f9b2cd3199f76a53138793afc1ebdf82601c12b"
 dependencies = [
  "bytes",
  "deno_core",
@@ -2302,20 +2274,20 @@ dependencies = [
  "once_cell",
  "rustls-tokio-stream",
  "serde",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "tokio",
 ]
 
 [[package]]
 name = "deno_webstorage"
-version = "0.189.0"
+version = "0.200.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc483a5d0d05e32a1ec646064ea00c7dcd21e0cbe53b23e70fa48f7d29811bfc"
+checksum = "c120f49410ced3722ef030c817fb9a10f1cd0c9b12b438de91cc466231780f83"
 dependencies = [
  "deno_core",
  "deno_error",
  "rusqlite",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -2330,9 +2302,9 @@ dependencies = [
 
 [[package]]
 name = "denokv_proto"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5b77de4d3b9215e14624d4f4eb16cb38c0810e3f5860ba3b3fc47d0537f9a4d"
+checksum = "fdc7c5c829ce15275d0898c94eecc243e2a47269a3f8ec5a1da45fe268a90886"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2346,9 +2318,9 @@ dependencies = [
 
 [[package]]
 name = "denokv_remote"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6497c28eec268ed99f1e8664f0842935f02d1508529c67d94c57ca5d893d743"
+checksum = "ecd57015ff7b5d51cd7a61b83baec8e38367631cd13dc77140412fe5143e15fb"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2363,7 +2335,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-util",
  "url",
@@ -2372,9 +2344,9 @@ dependencies = [
 
 [[package]]
 name = "denokv_sqlite"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0f21a450a35eb85760761401fddf9bfff9840127be07a6ca5c31863127913d"
+checksum = "01024c5ad6ce7838d27dc35cfcc0877eee57e07a25126ccaac8eb2b61a0cf04f"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2388,11 +2360,24 @@ dependencies = [
  "rand 0.8.5",
  "rusqlite",
  "serde_json",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "uuid",
  "v8_valueserializer",
+]
+
+[[package]]
+name = "denort_helper"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94ac464246974fec810ff9fc05803ec7f1467ae2e7e76a76bd9bec6ce282b1e9"
+dependencies = [
+ "deno_error",
+ "deno_path_util",
+ "sys_traits",
+ "thiserror 2.0.12",
+ "twox-hash",
 ]
 
 [[package]]
@@ -2497,10 +2482,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "dprint-swc-ext"
-version = "0.22.1"
+name = "dotenvy"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1716eda64b75d22f36c641fbb1ba097529259e4c152695e7670b96f9498fc926"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dprint-swc-ext"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a09827d6db1a3af25e105553d674ee9019be58fa3d6745c2a2803f8ce8e3eb8"
 dependencies = [
  "num-bigint",
  "rustc-hash 2.1.1",
@@ -2641,9 +2632,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.33"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
@@ -2674,12 +2665,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2708,10 +2699,11 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "faster-hex"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183"
+checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
 dependencies = [
+ "heapless",
  "serde",
 ]
 
@@ -2821,6 +2813,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2911,9 +2909,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2926,9 +2924,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2936,15 +2934,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2953,15 +2951,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2970,21 +2968,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3070,7 +3068,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 dependencies = [
  "fallible-iterator",
- "indexmap 2.6.0",
+ "indexmap 2.9.0",
  "stable_deref_trait",
 ]
 
@@ -3208,7 +3206,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.6.0",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3227,7 +3225,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.6.0",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3255,6 +3253,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3275,14 +3282,17 @@ name = "hashbrown"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.1",
 ]
 
 [[package]]
@@ -3297,6 +3307,16 @@ dependencies = [
  "flate2",
  "nom 7.1.3",
  "num-traits",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -3348,7 +3368,7 @@ dependencies = [
  "once_cell",
  "rand 0.9.0",
  "serde",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "tinyvec",
  "tokio",
  "tracing",
@@ -3372,7 +3392,7 @@ dependencies = [
  "resolv-conf",
  "serde",
  "smallvec",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -3786,12 +3806,12 @@ checksum = "1215d4d92511fbbdaea50e750e91f2429598ef817f02b579158e92803b52c00a"
 dependencies = [
  "boxed_error",
  "deno_error",
- "indexmap 2.6.0",
+ "indexmap 2.9.0",
  "log",
  "percent-encoding",
  "serde",
  "serde_json",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "url",
 ]
 
@@ -3807,9 +3827,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.6.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.1",
@@ -3910,6 +3930,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -4057,12 +4086,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "lcms2"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4093,9 +4116,9 @@ checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libffi"
-version = "3.2.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce826c243048e3d5cec441799724de52e2d42f820468431fc3fceee2341871e2"
+checksum = "4a9434b6fc77375fb624698d5f8c49d7e80b10d59eb1219afda27d1f824d4074"
 dependencies = [
  "libc",
  "libffi-sys",
@@ -4103,9 +4126,9 @@ dependencies = [
 
 [[package]]
 name = "libffi-sys"
-version = "2.3.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36115160c57e8529781b4183c2bb51fdc1f6d6d1ed345591d84be7703befb3c"
+checksum = "ead36a2496acfc8edd6cc32352110e9478ac5b9b5f5b9856ebd3d28019addb84"
 dependencies = [
  "cc",
 ]
@@ -4138,11 +4161,11 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "fbb8270bb4060bd76c6e96f20c52d80620f1d82a3470885694e41e0f81ef6fe7"
 dependencies = [
- "bindgen 0.69.5",
+ "bindgen",
  "cc",
  "pkg-config",
  "vcpkg",
@@ -4280,12 +4303,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memmem"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
-
-[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4332,9 +4349,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -4396,27 +4413,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e380993072e52eef724eddfcde0ed013b0c023c3f0417336ed041aa9f076994e"
 dependencies = [
  "arrayvec",
- "bit-set 0.8.0",
+ "bit-set",
  "bitflags 2.9.0",
  "cfg_aliases",
  "codespan-reporting",
  "hexf-parse",
- "indexmap 2.6.0",
+ "indexmap 2.9.0",
  "log",
  "rustc-hash 1.1.0",
  "serde",
  "spirv",
  "strum 0.26.3",
  "termcolor",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "unicode-xid",
 ]
 
 [[package]]
 name = "napi_sym"
-version = "0.124.0"
+version = "0.135.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50aefd752f4f5607c357d0547a1ee813feecb5e72e7039b4f114a7cc1f1abb98"
+checksum = "f0166fe95fb1a7a76615859d61ed40b8ce1931189cfdf1df81cdcfd8ff38e7c0"
 dependencies = [
  "quote",
  "serde",
@@ -4470,10 +4487,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "node_resolver"
-version = "0.32.0"
+name = "nix"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89042ff03954a5f0c48814ad5d060b0d7f7be9a7974f5fef80073f2685cb41a"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "node_resolver"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49baa3423d3ea08c85d8047652a0ec94400a42dbc2118c588b55f19708a99019"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4484,6 +4514,7 @@ dependencies = [
  "deno_media_type",
  "deno_package_json",
  "deno_path_util",
+ "deno_semver",
  "futures",
  "lazy-regex",
  "once_cell",
@@ -4492,7 +4523,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sys_traits",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "url",
 ]
 
@@ -4659,9 +4690,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oorandom"
@@ -4790,19 +4821,13 @@ dependencies = [
 
 [[package]]
 name = "os_pipe"
-version = "1.1.5"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57119c3b893986491ec9aa85056780d3a0f3cf4da7cc09dd3650dbd6c6738fb9"
+checksum = "5ffd2b0a5634335b135d5728d84c5e0fd726954b87111f7506a61c502280d982"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "outref"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f222829ae9293e33a9f5e9f440c6760a3d450a64affe1846486b140db81c1f4"
 
 [[package]]
 name = "outref"
@@ -4864,6 +4889,25 @@ dependencies = [
  "primeorder",
  "rand_core 0.6.4",
  "sha2",
+]
+
+[[package]]
+name = "par-core"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "757892557993c69e82f9de0f9051e87144278aa342f03bf53617bbf044554484"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "par-iter"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a5b20f31e9ba82bfcbbb54a67aa40be6cebec9f668ba5753be138f9523c531a"
+dependencies = [
+ "either",
+ "par-core",
 ]
 
 [[package]]
@@ -5099,7 +5143,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide 0.8.0",
+ "miniz_oxide 0.8.8",
 ]
 
 [[package]]
@@ -5277,7 +5321,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "rustls",
  "socket2",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -5296,7 +5340,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "tinyvec",
  "tracing",
  "web-time",
@@ -5593,15 +5637,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -5649,9 +5692,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.32.1"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+checksum = "37e34486da88d8e051c7c0e23c3f15fd806ea8546260aa2fec247e97242ec143"
 dependencies = [
  "bitflags 2.9.0",
  "fallible-iterator",
@@ -5768,9 +5811,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-tokio-stream"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22557157d7395bc30727745b365d923f1ecc230c4c80b176545f3f4f08c46e33"
+checksum = "faa7dc7c991d9164e55bbf1558029eb5b84d32cc4d61a7df5b8641b2deedc4b3"
 dependencies = [
  "futures",
  "rustls",
@@ -5809,7 +5852,7 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix",
+ "nix 0.27.1",
  "radix_trie",
  "unicode-segmentation",
  "unicode-width 0.1.13",
@@ -5822,7 +5865,7 @@ name = "rustyscript"
 version = "0.11.0"
 dependencies = [
  "async-trait",
- "base64-simd 0.8.0",
+ "base64-simd",
  "checksum",
  "criterion",
  "deno_ast",
@@ -5833,6 +5876,7 @@ dependencies = [
  "deno_cron",
  "deno_crypto",
  "deno_error",
+ "deno_features",
  "deno_fetch",
  "deno_ffi",
  "deno_fs",
@@ -5863,7 +5907,7 @@ dependencies = [
  "hyper-util",
  "libc",
  "maybe_path",
- "nix",
+ "nix 0.27.1",
  "node_resolver",
  "once_cell",
  "paste",
@@ -5871,7 +5915,7 @@ dependencies = [
  "rustyline",
  "serde",
  "sys_traits",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-util",
  "version-sync",
@@ -6055,7 +6099,7 @@ version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap 2.9.0",
  "itoa",
  "ryu",
  "serde",
@@ -6084,15 +6128,15 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.249.0"
+version = "0.256.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41bd50e0136873d94207fcbd1a78bd8da0b7bfa4537e1383377c7cf2c1d811b1"
+checksum = "69d69b4e574a9ec6bd0222463e50cf8531986d9c657543888e029d54d909b283"
 dependencies = [
  "deno_error",
  "num-bigint",
  "serde",
  "smallvec",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "v8",
 ]
 
@@ -6183,15 +6227,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simd-abstraction"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cadb29c57caadc51ff8346233b5cec1d240b68ce55cf1afc764818791876987"
-dependencies = [
- "outref 0.1.0",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6253,9 +6288,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "smartstring"
@@ -6280,36 +6315,16 @@ dependencies = [
 
 [[package]]
 name = "sourcemap"
-version = "8.0.1"
+version = "9.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "208d40b9e8cad9f93613778ea295ed8f3c2b1824217c6cfc7219d3f6f45b96d4"
+checksum = "bdee719193ae5c919a3ee43f64c2c0dd87f9b9a451d67918a2a5ec2e3c70561c"
 dependencies = [
- "base64-simd 0.7.0",
+ "base64-simd",
  "bitvec",
  "data-encoding",
  "debugid",
  "if_chain",
- "rustc-hash 1.1.0",
- "rustc_version 0.2.3",
- "serde",
- "serde_json",
- "unicode-id-start",
- "url",
-]
-
-[[package]]
-name = "sourcemap"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab08a862c70980b8e23698b507e272317ae52a608a164a844111f5372374f1f"
-dependencies = [
- "base64-simd 0.7.0",
- "bitvec",
- "data-encoding",
- "debugid",
- "if_chain",
- "rustc-hash 1.1.0",
- "rustc_version 0.2.3",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "unicode-id-start",
@@ -6373,15 +6388,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "string_capacity"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcd14cb3a5abda6d2626370785f5f788b22e95476f597159faa4a2cc2966961a"
-dependencies = [
- "itoa",
-]
-
-[[package]]
 name = "string_enum"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6395,18 +6401,9 @@ dependencies = [
 
 [[package]]
 name = "stringcase"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04028eeb851ed08af6aba5caa29f2d59a13ed168cee4d6bd753aeefcf1d636b0"
-
-[[package]]
-name = "strum"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
-dependencies = [
- "strum_macros 0.25.3",
-]
+checksum = "72abeda133c49d7bddece6c154728f83eec8172380c80ab7096da9487e20d27c"
 
 [[package]]
 name = "strum"
@@ -6418,12 +6415,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "strum_macros"
-version = "0.25.3"
+name = "strum"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 dependencies = [
- "heck 0.4.1",
+ "strum_macros 0.27.1",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -6432,9 +6438,9 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -6476,25 +6482,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "swc_cached"
-version = "2.0.0"
+name = "swc_common"
+version = "9.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7133338c3bef796430deced151b0eaa5430710a90e38da19e8e3045e8e36eeb"
+checksum = "a56b6f5a8e5affa271b56757a93badee6f44defcd28f3ba106bb2603afe40d3d"
 dependencies = [
  "anyhow",
- "dashmap",
- "once_cell",
- "regex",
- "rustc-hash 2.1.1",
- "serde",
-]
-
-[[package]]
-name = "swc_common"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fbd21a1179166b5635d4b7a6b5930cf34b803a7361e0297b04f84dc820db04"
-dependencies = [
  "ast_node",
  "better_scoped_tls",
  "cfg-if",
@@ -6506,7 +6499,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "siphasher",
- "sourcemap 9.0.0",
+ "sourcemap",
  "swc_allocator",
  "swc_atoms",
  "swc_eq_ignore_macros",
@@ -6518,15 +6511,14 @@ dependencies = [
 
 [[package]]
 name = "swc_config"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb63364aebd1a8490a80fa8933825c6916d4df55d5472312d5adb62c9fb4e4ba"
+checksum = "a01bfcbbdea182bdda93713aeecd997749ae324686bf7944f54d128e56be4ea9"
 dependencies = [
  "anyhow",
- "indexmap 2.6.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_json",
- "swc_cached",
  "swc_config_macro",
 ]
 
@@ -6544,14 +6536,16 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66db1e9b31f0f91ee0964aba014b4d2dfdc6c558732d106d762b43bedad2c4a"
+checksum = "0613d84468a6bb6d45d13c5a3368b37bd21f3067a089f69adac630dcb462a018"
 dependencies = [
  "bitflags 2.9.0",
  "is-macro",
  "num-bigint",
+ "once_cell",
  "phf",
+ "rustc-hash 2.1.1",
  "scoped-tls",
  "serde",
  "string_enum",
@@ -6563,9 +6557,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "8.0.1"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874889c00e41e5ae487886ff4af2533944584e8b479bc469a3f9708cab7ecdb7"
+checksum = "b01b3de365a86b8f982cc162f257c82f84bda31d61084174a3be37e8ab15c0f4"
 dependencies = [
  "ascii",
  "compact_str",
@@ -6575,7 +6569,7 @@ dependencies = [
  "regex",
  "rustc-hash 2.1.1",
  "serde",
- "sourcemap 9.0.0",
+ "sourcemap",
  "swc_allocator",
  "swc_atoms",
  "swc_common",
@@ -6586,9 +6580,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen_macros"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac2ff0957329e0dfcde86a1ac465382e189bf42a5989720d3476bea78eaa31a"
+checksum = "e99e1931669a67c83e2c2b4375674f6901d1480994a76aa75b23f1389e6c5076"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6597,26 +6591,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "swc_ecma_loader"
-version = "8.0.0"
+name = "swc_ecma_lexer"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a801462c997b71e4add7684ce4953c7d6200c75b5552b8d594783da84ad9564c"
+checksum = "0d11c8e71901401b9aae2ece4946eeb7674b14b8301a53768afbbeeb0e48b599"
 dependencies = [
- "anyhow",
- "pathdiff",
- "rustc-hash 2.1.1",
- "serde",
- "swc_atoms",
- "swc_common",
- "tracing",
-]
-
-[[package]]
-name = "swc_ecma_parser"
-version = "10.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e336f2b460882df2c132328b3c29ab3e680e1db681a05ec3e406940d98320a"
-dependencies = [
+ "arrayvec",
+ "bitflags 2.9.0",
  "either",
  "new_debug_unreachable",
  "num-bigint",
@@ -6635,15 +6616,57 @@ dependencies = [
 ]
 
 [[package]]
-name = "swc_ecma_transforms_base"
-version = "11.1.1"
+name = "swc_ecma_loader"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f823fb2ba61099c06f1557f4d7bc3a957147f2e39f92419204682aa62b46fc"
+checksum = "8eb574d660c05f3483c984107452b386e45b95531bdb1253794077edc986f413"
+dependencies = [
+ "anyhow",
+ "pathdiff",
+ "rustc-hash 2.1.1",
+ "serde",
+ "swc_atoms",
+ "swc_common",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_parser"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250786944fbc05f6484eda9213df129ccfe17226ae9ad51b62fce2f72135dbee"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.9.0",
+ "either",
+ "new_debug_unreachable",
+ "num-bigint",
+ "num-traits",
+ "phf",
+ "rustc-hash 2.1.1",
+ "serde",
+ "smallvec",
+ "smartstring",
+ "stacker",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_lexer",
+ "tracing",
+ "typed-arena",
+]
+
+[[package]]
+name = "swc_ecma_transforms_base"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6856da3da598f4da001b7e4ce225ee8970bc9d5cbaafcaf580190cf0a6031ec5"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.9.0",
- "indexmap 2.6.0",
+ "indexmap 2.9.0",
  "once_cell",
+ "par-core",
  "phf",
  "rustc-hash 2.1.1",
  "serde",
@@ -6654,15 +6677,14 @@ dependencies = [
  "swc_ecma_parser",
  "swc_ecma_utils",
  "swc_ecma_visit",
- "swc_parallel",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "11.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2111a904b8f3c5dd63f56e7c8048851fcd8f748691a162a5d19a5da49f4a9d35"
+checksum = "0f84248f82bad599d250bbcd52cb4db6ff6409f48267fd6f001302a2e9716f80"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6686,9 +6708,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "11.0.1"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3072700bb4401fffed5a152248d0d173a41da94584a4267355fa6772538880b"
+checksum = "193237e318421ef621c2b3958b4db174770c5280ef999f1878f2df93a2837ca6"
 dependencies = [
  "either",
  "rustc-hash 2.1.1",
@@ -6706,13 +6728,13 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "12.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311218980029ea376a1f53292418d852d50b461d15d9d39f830abf0d1c3bdd6c"
+checksum = "baae39c70229103a72090119887922fc5e32f934f5ca45c0423a5e65dac7e549"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "dashmap",
- "indexmap 2.6.0",
+ "indexmap 2.9.0",
  "once_cell",
  "rustc-hash 2.1.1",
  "serde",
@@ -6732,9 +6754,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "12.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c32ebb3dd1942d35142de60c9dc0f3c034d26567de7eb8b3ad6de426f5b0e9"
+checksum = "a3c65e0b49f7e2a2bd92f1d89c9a404de27232ce00f6a4053f04bda446d50e5c"
 dependencies = [
  "once_cell",
  "rustc-hash 2.1.1",
@@ -6751,29 +6773,30 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "11.0.0"
+version = "13.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721dc779e7de200da96ac4002c710bc32c988e3e1ebf62b39d32bf99f14d9765"
+checksum = "7ed837406d5dbbfbf5792b1dc90964245a0cf659753d4745fe177ffebe8598b9"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap 2.9.0",
  "num_cpus",
  "once_cell",
+ "par-core",
+ "par-iter",
  "rustc-hash 2.1.1",
  "ryu-js",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_visit",
- "swc_parallel",
  "tracing",
  "unicode-id",
 ]
 
 [[package]]
 name = "swc_ecma_visit"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7a65fa06d0c0f709f1df4e820ccdc4eca7b3db7f9d131545e20c2ac2f1cd23"
+checksum = "249dc9eede1a4ad59a038f9cfd61ce67845bd2c1392ade3586d714e7181f3c1a"
 dependencies = [
  "new_debug_unreachable",
  "num-bigint",
@@ -6815,15 +6838,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.87",
-]
-
-[[package]]
-name = "swc_parallel"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f75f1094d69174ef628e3665fff0f81d58e9f568802e3c90d332c72b0b6026"
-dependencies = [
- "once_cell",
 ]
 
 [[package]]
@@ -6905,10 +6919,11 @@ dependencies = [
 
 [[package]]
 name = "sys_traits"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "638f0e61b5134e56b2abdf4c704fd44672603f15ca09013f314649056f3fee4d"
+checksum = "f3374191d43a934854e99a46cd47f8124369e690353e0f8db42769218d083690"
 dependencies = [
+ "getrandom 0.2.15",
  "libc",
  "windows-sys 0.59.0",
 ]
@@ -6973,11 +6988,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.4"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f49a1853cf82743e3b7950f77e0f4d622ca36cf4317cba00c767838bac8d490"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.4",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -6993,9 +7008,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.4"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8381894bb3efe0c4acac3ded651301ceee58a15d47c2e34885ed1908ad667061"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7181,6 +7196,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-vsock"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1824fc0300433f400df6b6264a9ab00ba93f39d38c3157fb5f05183476c4af10"
+dependencies = [
+ "bytes",
+ "futures",
+ "libc",
+ "tokio",
+ "vsock",
+]
+
+[[package]]
 name = "toml"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7207,7 +7235,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -7579,17 +7607,16 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "134.5.0"
+version = "137.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21c7a224a7eaf3f98c1bad772fbaee56394dce185ef7b19a2e0ca5e3d274165d"
+checksum = "be127b878f582d3b7602bd2e26a39f90a95b388deb940da7f6554617aedcdf40"
 dependencies = [
- "bindgen 0.70.1",
+ "bindgen",
  "bitflags 2.9.0",
  "fslock",
  "gzip-header",
  "home",
- "miniz_oxide 0.7.4",
- "once_cell",
+ "miniz_oxide 0.8.8",
  "paste",
  "which",
 ]
@@ -7602,7 +7629,7 @@ checksum = "97599c400fc79925922b58303e98fcb8fa88f573379a08ddb652e72cbd2e70f6"
 dependencies = [
  "bitflags 2.9.0",
  "encoding_rs",
- "indexmap 2.6.0",
+ "indexmap 2.9.0",
  "num-bigint",
  "serde",
  "thiserror 1.0.66",
@@ -7659,6 +7686,16 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "vsock"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e8b4d00e672f147fc86a09738fadb1445bd1c0a40542378dfb82909deeee688"
+dependencies = [
+ "libc",
+ "nix 0.29.0",
+]
 
 [[package]]
 name = "walkdir"
@@ -7777,7 +7814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eeee3bdea6257cc36d756fa745a70f9d393571e47d69e0ed97581676a5369ca"
 dependencies = [
  "deno_error",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -7808,7 +7845,7 @@ checksum = "c564e589056437e3a73383f4e0903965879087c9ee0f715e562bbf4e47c08b75"
 dependencies = [
  "bytes",
  "http 1.1.0",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "url",
 ]
 
@@ -7837,11 +7874,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "671c25545d479b47d3f0a8e373aceb2060b67c6eb841b24ac8c32348151c7a0c"
 dependencies = [
  "arrayvec",
- "bit-vec 0.8.0",
+ "bit-vec",
  "bitflags 2.9.0",
  "cfg_aliases",
  "document-features",
- "indexmap 2.6.0",
+ "indexmap 2.9.0",
  "log",
  "naga",
  "once_cell",
@@ -7852,7 +7889,7 @@ dependencies = [
  "rustc-hash 1.1.0",
  "serde",
  "smallvec",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "wgpu-hal",
  "wgpu-types",
 ]
@@ -7866,7 +7903,7 @@ dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
- "bit-set 0.8.0",
+ "bit-set",
  "bitflags 2.9.0",
  "block",
  "bytemuck",
@@ -7894,7 +7931,7 @@ dependencies = [
  "raw-window-handle",
  "rustc-hash 1.1.0",
  "smallvec",
- "thiserror 2.0.4",
+ "thiserror 2.0.12",
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,7 @@ worker = []
 
 [dependencies]
 maybe_path = "0.1.3"
-thiserror = "^2.0.3"
+thiserror = "^2.0.12"
 serde = "^1.0.149"
 
 # Used for NodeJS compatibility and other features
@@ -164,12 +164,13 @@ async-trait = "^0.1.73"
 paste = "1.0.15"
 
 # The deno runtime itself, and the webidl extension for the web APIs
-deno_core = "^0.340.0"
-deno_error = "=0.5.5"
+deno_core = "^0.347.0"
+deno_error = "=0.5.6"
+deno_features = "0.2.0"
 
 # For transpiling typescript
-deno_ast = { version = "=0.46.0", features = ["transpiling", "cjs"] }
-deno_media_type = "=0.2.6"
+deno_ast = { version = "=0.47.0", features = ["transpiling", "cjs"] }
+deno_media_type = "=0.2.8"
 
 # Runtime for async tasks
 tokio = "^1.36.0"
@@ -182,37 +183,37 @@ hyper-util = {version = "^0.1.10", optional = true}
 # Pinned for now due to upstream issues
 reqwest = { version = "=0.12.8", optional = true, default-features = false, features = ["blocking", "rustls-tls"] }
 http = { version = "^1.0", optional = true }
-deno_permissions = { version = "^0.53.0", optional = true }
+deno_permissions = { version = "^0.64.0", optional = true }
 
 
 #
 # Dependencies for the various extension features
 #
 
-deno_broadcast_channel = { version = "^0.188.0", optional = true }
+deno_broadcast_channel = { version = "^0.199.0", optional = true }
 
-deno_cache      = { version = "^0.126.0", optional = true }
-deno_console    = { version = "^0.194.0", optional = true }
-deno_cron       = { version = "^0.74.0", optional = true }
-deno_crypto     = { version = "^0.208.0", optional = true }
-deno_fetch      = { version = "^0.218.0", optional = true }
-deno_ffi        = { version = "^0.181.0", optional = true }
-deno_fs         = { version = "^0.104.0", optional = true, features = ["sync_fs"] }
-deno_http       = { version = "^0.192.0", optional = true }
-deno_kv         = { version = "^0.102.0", optional = true }
-deno_net        = { version = "^0.186.0", optional = true }
-deno_node       = { version = "^0.132.0", optional = true }
-deno_tls        = { version = "^0.181.0", optional = true }
-deno_url        = { version = "^0.194.0", optional = true }
+deno_cache      = { version = "^0.137.0", optional = true }
+deno_console    = { version = "^0.205.0", optional = true }
+deno_cron       = { version = "^0.85.0", optional = true }
+deno_crypto     = { version = "^0.219.0", optional = true }
+deno_fetch      = { version = "^0.229.0", optional = true }
+deno_ffi        = { version = "^0.192.0", optional = true }
+deno_fs         = { version = "^0.115.0", optional = true, features = ["sync_fs"] }
+deno_http       = { version = "^0.203.0", optional = true }
+deno_kv         = { version = "^0.113.0", optional = true }
+deno_net        = { version = "^0.197.0", optional = true }
+deno_node       = { version = "^0.143.0", optional = true }
+deno_tls        = { version = "^0.192.0", optional = true }
+deno_url        = { version = "^0.205.0", optional = true }
 
-deno_web        = { version = "^0.225.0", optional = true }
-deno_webidl     = { version = "^0.194.0", optional = true }
-deno_webstorage = { version = "^0.189.0", optional = true }
-deno_websocket  = { version = "^0.199.0", optional = true }
-deno_webgpu     = { version = "^0.161.0", optional = true }
+deno_web        = { version = "^0.236.0", optional = true }
+deno_webidl     = { version = "^0.205.0", optional = true }
+deno_webstorage = { version = "^0.200.0", optional = true }
+deno_websocket  = { version = "^0.210.0", optional = true }
+deno_webgpu     = { version = "^0.172.0", optional = true }
 
-deno_io = { version = "^0.104.0", optional = true }
-deno_telemetry  = { version = "^0.16.0", optional = true }
+deno_io = { version = "^0.115.0", optional = true }
+deno_telemetry  = { version = "^0.27.0", optional = true }
 
 # Dependencies for the IO feature
 rustyline = {version = "=13.0.0", optional = true}
@@ -229,17 +230,17 @@ once_cell = {version = "^1.17.1", optional = true}
 base64-simd = {version = "0.8.0", optional = true}
 
 # Dependencies for the node feature
-deno_resolver = { version = "^0.25.0", optional = true }
-node_resolver = { version = "^0.32.0", optional = true, features = ["sync"] }
-deno_runtime  = { version = "^0.202.0", optional = true, features = ["exclude_runtime_main_js"] }
-deno_terminal = { version = "^0.2.0", optional = true }
+deno_resolver = { version = "^0.36.0", optional = true }
+node_resolver = { version = "^0.43.0", optional = true, features = ["sync"] }
+deno_runtime  = { version = "^0.213.0", optional = true, features = ["exclude_runtime_main_js"] }
+deno_terminal = { version = "=0.2.2", optional = true }
 deno_semver   = { version = "=0.7.1", optional = true }
-deno_napi     = { version = "^0.125.0", optional = true }
-deno_npm      = { version = "=0.27.2", optional = true }
-deno_process  = { version = "^0.9.0", optional = true }
-deno_package_json = { version = "=0.5.0", optional = true }
+deno_napi     = { version = "^0.136.0", optional = true }
+deno_npm      = { version = "=0.33.3", optional = true }
+deno_process  = { version = "^0.20.0", optional = true }
+deno_package_json = { version = "=0.6.0", optional = true }
 checksum      = { version = "0.2.1", optional = true }
-sys_traits    = { version = "=0.1.8", optional = true }
+sys_traits    = { version = "=0.1.9", optional = true }
 
 [dev-dependencies]
 version-sync = "0.9.5"

--- a/examples/custom_runtimes.rs
+++ b/examples/custom_runtimes.rs
@@ -33,7 +33,7 @@ impl MyRuntime {
     /// Create a new instance of the runtime
     pub fn new() -> Result<Self, Error> {
         let mut runtime = Self(Runtime::new(RuntimeOptions {
-            extensions: vec![example_extension::example_extension::init_ops_and_esm()],
+            extensions: vec![example_extension::example_extension::init()],
             timeout: Duration::from_millis(500),
             ..Default::default()
         })?);

--- a/examples/runtime_extensions.rs
+++ b/examples/runtime_extensions.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), Error> {
     // allow clone or copy from extensions
     let mut runtime = Runtime::new(RuntimeOptions {
         schema_whlist,
-        extensions: vec![example_extension::example_extension::init_ops_and_esm()],
+        extensions: vec![example_extension::example_extension::init()],
         ..Default::default()
     })?;
     let module_handle = runtime.load_module(&module)?;

--- a/src/ext/broadcast_channel/mod.rs
+++ b/src/ext/broadcast_channel/mod.rs
@@ -13,12 +13,12 @@ extension!(
 );
 impl ExtensionTrait<()> for init_broadcast_channel {
     fn init((): ()) -> Extension {
-        init_broadcast_channel::init_ops_and_esm()
+        init_broadcast_channel::init()
     }
 }
 impl ExtensionTrait<InMemoryBroadcastChannel> for deno_broadcast_channel::deno_broadcast_channel {
     fn init(channel: InMemoryBroadcastChannel) -> Extension {
-        deno_broadcast_channel::deno_broadcast_channel::init_ops_and_esm(channel)
+        deno_broadcast_channel::deno_broadcast_channel::init(channel)
     }
 }
 

--- a/src/ext/cache/mod.rs
+++ b/src/ext/cache/mod.rs
@@ -13,12 +13,12 @@ extension!(
 );
 impl ExtensionTrait<()> for init_cache {
     fn init((): ()) -> Extension {
-        init_cache::init_ops_and_esm()
+        init_cache::init()
     }
 }
 impl ExtensionTrait<Option<deno_cache::CreateCache>> for deno_cache::deno_cache {
     fn init(options: Option<deno_cache::CreateCache>) -> Extension {
-        deno_cache::deno_cache::init_ops_and_esm(options)
+        deno_cache::deno_cache::init(options)
     }
 }
 

--- a/src/ext/console/mod.rs
+++ b/src/ext/console/mod.rs
@@ -10,12 +10,12 @@ extension!(
 impl ExtensionTrait<()> for init_console {
     fn init((): ()) -> Extension {
         deno_terminal::colors::set_use_color(true);
-        init_console::init_ops_and_esm()
+        init_console::init()
     }
 }
 impl ExtensionTrait<()> for deno_console::deno_console {
     fn init((): ()) -> Extension {
-        deno_console::deno_console::init_ops_and_esm()
+        deno_console::deno_console::init()
     }
 }
 

--- a/src/ext/cron/mod.rs
+++ b/src/ext/cron/mod.rs
@@ -10,12 +10,12 @@ extension!(
 );
 impl ExtensionTrait<()> for init_cron {
     fn init((): ()) -> Extension {
-        init_cron::init_ops_and_esm()
+        init_cron::init()
     }
 }
 impl ExtensionTrait<()> for deno_cron::deno_cron {
     fn init((): ()) -> Extension {
-        deno_cron::deno_cron::init_ops_and_esm(LocalCronHandler::new())
+        deno_cron::deno_cron::init(LocalCronHandler::new())
     }
 }
 

--- a/src/ext/crypto/mod.rs
+++ b/src/ext/crypto/mod.rs
@@ -9,12 +9,12 @@ extension!(
 );
 impl ExtensionTrait<()> for init_crypto {
     fn init((): ()) -> Extension {
-        init_crypto::init_ops_and_esm()
+        init_crypto::init()
     }
 }
 impl ExtensionTrait<Option<u64>> for deno_crypto::deno_crypto {
     fn init(seed: Option<u64>) -> Extension {
-        deno_crypto::deno_crypto::init_ops_and_esm(seed)
+        deno_crypto::deno_crypto::init(seed)
     }
 }
 

--- a/src/ext/ffi/mod.rs
+++ b/src/ext/ffi/mod.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use super::{web::PermissionsContainer, ExtensionTrait};
 use deno_core::{extension, Extension};
 
@@ -9,12 +11,12 @@ extension!(
 );
 impl ExtensionTrait<()> for init_ffi {
     fn init((): ()) -> Extension {
-        init_ffi::init_ops_and_esm()
+        init_ffi::init()
     }
 }
 impl ExtensionTrait<()> for deno_ffi::deno_ffi {
     fn init((): ()) -> Extension {
-        deno_ffi::deno_ffi::init_ops_and_esm::<PermissionsContainer>()
+        deno_ffi::deno_ffi::init::<PermissionsContainer>(None)
     }
 }
 
@@ -36,7 +38,9 @@ impl deno_ffi::FfiPermissions for PermissionsContainer {
         path: &str,
     ) -> Result<std::path::PathBuf, deno_permissions::PermissionCheckError> {
         self.check_partial_no_path()?;
-        let p = self.0.check_read(std::path::Path::new(path), None)?;
+        let p = self
+            .0
+            .check_read(Cow::Borrowed(std::path::Path::new(path)), None)?;
         Ok(p.to_path_buf())
     }
 }

--- a/src/ext/http/mod.rs
+++ b/src/ext/http/mod.rs
@@ -5,7 +5,7 @@ mod http_runtime;
 use http_runtime::deno_http_runtime;
 impl ExtensionTrait<()> for deno_http_runtime {
     fn init((): ()) -> Extension {
-        deno_http_runtime::init_ops_and_esm()
+        deno_http_runtime::init()
     }
 }
 
@@ -17,14 +17,15 @@ extension!(
 );
 impl ExtensionTrait<()> for init_http {
     fn init((): ()) -> Extension {
-        init_http::init_ops_and_esm()
+        init_http::init()
     }
 }
 impl ExtensionTrait<()> for deno_http::deno_http {
     fn init((): ()) -> Extension {
-        deno_http::deno_http::init_ops_and_esm(deno_http::Options {
+        deno_http::deno_http::init(deno_http::Options {
             http2_builder_hook: None,
             http1_builder_hook: None,
+            no_legacy_abort: false,
         })
     }
 }

--- a/src/ext/io/mod.rs
+++ b/src/ext/io/mod.rs
@@ -19,17 +19,17 @@ extension!(
 );
 impl ExtensionTrait<()> for init_io {
     fn init((): ()) -> Extension {
-        init_io::init_ops_and_esm()
+        init_io::init()
     }
 }
 impl ExtensionTrait<Option<deno_io::Stdio>> for deno_io::deno_io {
     fn init(pipes: Option<deno_io::Stdio>) -> Extension {
-        deno_io::deno_io::init_ops_and_esm(pipes)
+        deno_io::deno_io::init(pipes)
     }
 }
 impl ExtensionTrait<()> for tty::deno_tty {
     fn init((): ()) -> Extension {
-        tty::deno_tty::init_ops_and_esm()
+        tty::deno_tty::init()
     }
 }
 

--- a/src/ext/kv/mod.rs
+++ b/src/ext/kv/mod.rs
@@ -5,7 +5,7 @@ use deno_kv::{
     remote::{RemoteDbHandler, RemoteDbHandlerPermissions},
     sqlite::{SqliteDbHandler, SqliteDbHandlerPermissions},
 };
-use std::path::PathBuf;
+use std::{borrow::Cow, path::PathBuf};
 
 extension!(
     init_kv,
@@ -15,12 +15,12 @@ extension!(
 );
 impl ExtensionTrait<()> for init_kv {
     fn init((): ()) -> Extension {
-        init_kv::init_ops_and_esm()
+        init_kv::init()
     }
 }
 impl ExtensionTrait<KvStore> for deno_kv::deno_kv {
     fn init(store: KvStore) -> Extension {
-        deno_kv::deno_kv::init_ops_and_esm(store.handler(), store.config())
+        deno_kv::deno_kv::init(store.handler(), store.config())
     }
 }
 
@@ -179,13 +179,15 @@ impl SqliteDbHandlerPermissions for PermissionsContainer {
         p: &str,
         api_name: &str,
     ) -> Result<std::path::PathBuf, deno_permissions::PermissionCheckError> {
-        let p = self.0.check_read(std::path::Path::new(p), Some(api_name))?;
+        let p = self
+            .0
+            .check_read(Cow::Borrowed(std::path::Path::new(p)), Some(api_name))?;
         Ok(p.to_path_buf())
     }
 
     fn check_write<'a>(
         &mut self,
-        p: &'a std::path::Path,
+        p: Cow<'a, std::path::Path>,
         api_name: &str,
     ) -> Result<std::borrow::Cow<'a, std::path::Path>, deno_permissions::PermissionCheckError> {
         let p = self.0.check_write(p, Some(api_name))?;

--- a/src/ext/mod.rs
+++ b/src/ext/mod.rs
@@ -10,20 +10,23 @@ pub mod rustyscript;
 trait ExtensionTrait<A> {
     fn init(options: A) -> Extension;
 
-    /// Makes a call to `init_ops_and_esm` equivalent to `init_ops`
-    fn set_esm(mut ext: Extension, is_snapshot: bool) -> Extension {
-        if is_snapshot {
-            ext.js_files = ::std::borrow::Cow::Borrowed(&[]);
-            ext.esm_files = ::std::borrow::Cow::Borrowed(&[]);
-            ext.esm_entry_point = ::std::option::Option::None;
-        }
+    // Clears the js and esm files for warmup to avoid reloading them
+    fn for_warmup(mut ext: Extension) -> Extension {
+        ext.js_files = ::std::borrow::Cow::Borrowed(&[]);
+        ext.esm_files = ::std::borrow::Cow::Borrowed(&[]);
+        ext.esm_entry_point = ::std::option::Option::None;
+
         ext
     }
 
     /// Builds an extension
     fn build(options: A, is_snapshot: bool) -> Extension {
-        let ext = Self::init(options);
-        Self::set_esm(ext, is_snapshot)
+        let ext: Extension = Self::init(options);
+        if is_snapshot {
+            Self::for_warmup(ext)
+        } else {
+            ext
+        }
     }
 }
 

--- a/src/ext/napi/mod.rs
+++ b/src/ext/napi/mod.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use super::{web::PermissionsContainer, ExtensionTrait};
 use deno_core::{extension, Extension};
 
@@ -9,12 +11,12 @@ extension!(
 );
 impl ExtensionTrait<()> for init_napi {
     fn init((): ()) -> Extension {
-        init_napi::init_ops_and_esm()
+        init_napi::init()
     }
 }
 impl ExtensionTrait<()> for deno_napi::deno_napi {
     fn init((): ()) -> Extension {
-        deno_napi::deno_napi::init_ops_and_esm::<PermissionsContainer>()
+        deno_napi::deno_napi::init::<PermissionsContainer>(None)
     }
 }
 
@@ -30,7 +32,9 @@ impl deno_napi::NapiPermissions for PermissionsContainer {
         &mut self,
         path: &str,
     ) -> Result<std::path::PathBuf, deno_permissions::PermissionCheckError> {
-        let p = self.0.check_read(std::path::Path::new(path), None)?;
+        let p = self
+            .0
+            .check_read(Cow::Borrowed(std::path::Path::new(path)), None)?;
         Ok(p.to_path_buf())
     }
 }

--- a/src/ext/runtime/init_runtime.js
+++ b/src/ext/runtime/init_runtime.js
@@ -79,6 +79,6 @@ applyToDeno({
 
 import * as _console from 'ext:deno_console/01_console.js';
 _console.setNoColorFns(
-    () => globalThis.Deno.core.ops.op_bootstrap_no_color() || !globalThis.Deno.core.ops.op_bootstrap_is_stdout_tty(),
-    () => globalThis.Deno.core.ops.op_bootstrap_no_color() || !globalThis.Deno.core.ops.op_bootstrap_is_stderr_tty(),
+    () => globalThis.Deno.core.ops.op_bootstrap_no_color(),
+    () => globalThis.Deno.core.ops.op_bootstrap_no_color(),
 );

--- a/src/ext/rustyscript/mod.rs
+++ b/src/ext/rustyscript/mod.rs
@@ -70,7 +70,7 @@ extension!(
 );
 impl ExtensionTrait<()> for rustyscript {
     fn init(options: ()) -> Extension {
-        rustyscript::init_ops_and_esm()
+        rustyscript::init()
     }
 }
 

--- a/src/ext/url/mod.rs
+++ b/src/ext/url/mod.rs
@@ -9,12 +9,12 @@ extension!(
 );
 impl ExtensionTrait<()> for init_url {
     fn init((): ()) -> Extension {
-        init_url::init_ops_and_esm()
+        init_url::init()
     }
 }
 impl ExtensionTrait<()> for deno_url::deno_url {
     fn init((): ()) -> Extension {
-        deno_url::deno_url::init_ops_and_esm()
+        deno_url::deno_url::init()
     }
 }
 

--- a/src/ext/web/mod.rs
+++ b/src/ext/web/mod.rs
@@ -20,7 +20,7 @@ extension!(
 );
 impl ExtensionTrait<WebOptions> for init_fetch {
     fn init(options: WebOptions) -> Extension {
-        init_fetch::init_ops_and_esm()
+        init_fetch::init()
     }
 }
 impl ExtensionTrait<WebOptions> for deno_fetch::deno_fetch {
@@ -37,7 +37,7 @@ impl ExtensionTrait<WebOptions> for deno_fetch::deno_fetch {
             resolver: options.resolver.clone(),
         };
 
-        deno_fetch::deno_fetch::init_ops_and_esm::<PermissionsContainer>(options)
+        deno_fetch::deno_fetch::init::<PermissionsContainer>(options)
     }
 }
 
@@ -49,12 +49,12 @@ extension!(
 );
 impl ExtensionTrait<WebOptions> for init_net {
     fn init(options: WebOptions) -> Extension {
-        init_net::init_ops_and_esm()
+        init_net::init()
     }
 }
 impl ExtensionTrait<WebOptions> for deno_net::deno_net {
     fn init(options: WebOptions) -> Extension {
-        deno_net::deno_net::init_ops_and_esm::<PermissionsContainer>(
+        deno_net::deno_net::init::<PermissionsContainer>(
             options.root_cert_store_provider.clone(),
             options.unsafely_ignore_certificate_errors.clone(),
         )
@@ -69,13 +69,13 @@ extension!(
 );
 impl ExtensionTrait<()> for init_telemetry {
     fn init((): ()) -> Extension {
-        init_telemetry::init_ops_and_esm()
+        init_telemetry::init()
     }
 }
 
 impl ExtensionTrait<()> for deno_telemetry::deno_telemetry {
     fn init((): ()) -> Extension {
-        deno_telemetry::deno_telemetry::init_ops_and_esm()
+        deno_telemetry::deno_telemetry::init()
     }
 }
 
@@ -91,22 +91,19 @@ extension!(
 );
 impl ExtensionTrait<WebOptions> for init_web {
     fn init(options: WebOptions) -> Extension {
-        init_web::init_ops_and_esm(options.permissions)
+        init_web::init(options.permissions)
     }
 }
 
 impl ExtensionTrait<WebOptions> for deno_web::deno_web {
     fn init(options: WebOptions) -> Extension {
-        deno_web::deno_web::init_ops_and_esm::<PermissionsContainer>(
-            options.blob_store,
-            options.base_url,
-        )
+        deno_web::deno_web::init::<PermissionsContainer>(options.blob_store, options.base_url)
     }
 }
 
 impl ExtensionTrait<()> for deno_tls::deno_tls {
     fn init((): ()) -> Extension {
-        deno_tls::deno_tls::init_ops_and_esm()
+        deno_tls::deno_tls::init()
     }
 }
 

--- a/src/ext/web_stub/mod.rs
+++ b/src/ext/web_stub/mod.rs
@@ -19,7 +19,7 @@ extension!(
 );
 impl ExtensionTrait<()> for deno_web {
     fn init((): ()) -> Extension {
-        deno_web::init_ops_and_esm()
+        deno_web::init()
     }
 }
 

--- a/src/ext/webgpu/mod.rs
+++ b/src/ext/webgpu/mod.rs
@@ -9,12 +9,12 @@ extension!(
 );
 impl ExtensionTrait<()> for init_webgpu {
     fn init((): ()) -> Extension {
-        init_webgpu::init_ops_and_esm()
+        init_webgpu::init()
     }
 }
 impl ExtensionTrait<()> for deno_webgpu::deno_webgpu {
     fn init((): ()) -> Extension {
-        deno_webgpu::deno_webgpu::init_ops_and_esm()
+        deno_webgpu::deno_webgpu::init()
     }
 }
 

--- a/src/ext/webidl/mod.rs
+++ b/src/ext/webidl/mod.rs
@@ -9,12 +9,12 @@ extension!(
 );
 impl ExtensionTrait<()> for init_webidl {
     fn init((): ()) -> Extension {
-        init_webidl::init_ops_and_esm()
+        init_webidl::init()
     }
 }
 impl ExtensionTrait<()> for deno_webidl::deno_webidl {
     fn init((): ()) -> Extension {
-        deno_webidl::deno_webidl::init_ops_and_esm()
+        deno_webidl::deno_webidl::init()
     }
 }
 

--- a/src/ext/websocket/mod.rs
+++ b/src/ext/websocket/mod.rs
@@ -17,12 +17,12 @@ extension!(
 );
 impl ExtensionTrait<()> for init_websocket {
     fn init((): ()) -> Extension {
-        init_websocket::init_ops_and_esm()
+        init_websocket::init()
     }
 }
 impl ExtensionTrait<WebOptions> for deno_websocket::deno_websocket {
     fn init(options: WebOptions) -> Extension {
-        deno_websocket::deno_websocket::init_ops_and_esm::<PermissionsContainer>(
+        deno_websocket::deno_websocket::init::<PermissionsContainer>(
             options.user_agent,
             options.root_cert_store_provider,
             options.unsafely_ignore_certificate_errors,

--- a/src/ext/webstorage/mod.rs
+++ b/src/ext/webstorage/mod.rs
@@ -10,12 +10,12 @@ extension!(
 );
 impl ExtensionTrait<()> for init_webstorage {
     fn init((): ()) -> Extension {
-        init_webstorage::init_ops_and_esm()
+        init_webstorage::init()
     }
 }
 impl ExtensionTrait<Option<PathBuf>> for deno_webstorage::deno_webstorage {
     fn init(origin_storage_dir: Option<PathBuf>) -> Extension {
-        deno_webstorage::deno_webstorage::init_ops_and_esm(origin_storage_dir)
+        deno_webstorage::deno_webstorage::init(origin_storage_dir)
     }
 }
 

--- a/src/js_value/string.rs
+++ b/src/js_value/string.rs
@@ -60,7 +60,7 @@ impl String {
         let u8_len = local.utf8_length(scope);
         let mut buffer = vec![0; u8_len];
 
-        local.write_utf8_v2(scope, &mut buffer, WriteFlags::empty());
+        local.write_utf8_v2(scope, &mut buffer, WriteFlags::empty(), None);
         buffer
     }
 }

--- a/src/module_loader/inner_loader.rs
+++ b/src/module_loader/inner_loader.rs
@@ -165,9 +165,13 @@ impl InnerRustyLoader {
         kind: deno_core::ResolutionKind,
     ) -> Result<ModuleSpecifier, ModuleLoaderError> {
         #[cfg(feature = "node_experimental")]
-        let referrer_specifier = referrer
-            .to_module_specifier(&self.cwd)
-            .map_err(|e| JsErrorBox::from_err(to_io_err(e)))?;
+        let referrer_specifier = if deno_core::specifier_has_uri_scheme(referrer) {
+            deno_core::resolve_url(referrer)?
+        } else {
+            referrer
+                .to_module_specifier(&self.cwd)
+                .map_err(|e| JsErrorBox::from_err(to_io_err(e)))?
+        };
 
         //
         // Handle import aliasing for node imports

--- a/src/op_whitelist.js
+++ b/src/op_whitelist.js
@@ -132,6 +132,7 @@ export const whitelist = {
     "op_current_user_call_site": "V8 op - non breaking",
     "op_set_format_exception_callback": "V8 op - non breaking",
     "op_event_loop_has_more_work": "V8 op - non breaking",
+    "op_get_ext_import_meta_proto": "V8 op - non breaking",
 
     //
     // Cache    

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1148,7 +1148,7 @@ mod test_runtime {
 
         extension!(test_extension);
         Runtime::new(RuntimeOptions {
-            extensions: vec![test_extension::init_ops_and_esm()],
+            extensions: vec![test_extension::init()],
             ..Default::default()
         })
         .expect("Could not create runtime with extensions");

--- a/src/runtime_builder.rs
+++ b/src/runtime_builder.rs
@@ -28,7 +28,6 @@ impl RuntimeBuilder {
     ///
     /// This can be used to add custom functionality to the runtime
     ///
-    /// If the extension is for use with a snapshot, create the extension with `init_ops` instead of `init_ops_and_esm`
     #[must_use]
     pub fn with_extension(mut self, extension: deno_core::Extension) -> Self {
         self.0.extensions.push(extension);
@@ -39,7 +38,6 @@ impl RuntimeBuilder {
     ///
     /// This can be used to add custom functionality to the runtime
     ///
-    /// If the extension is for use with a snapshot, create the extension with `init_ops` instead of `init_ops_and_esm`
     #[must_use]
     pub fn with_extensions(mut self, extensions: Vec<deno_core::Extension>) -> Self {
         self.0.extensions.extend(extensions);
@@ -81,8 +79,6 @@ impl RuntimeBuilder {
     /// Set the startup snapshot for the runtime
     ///
     /// This will reduce load times, but requires the same extensions to be loaded as when the snapshot was created
-    ///
-    /// If provided, user-supplied extensions must be instantiated with `init_ops` instead of `init_ops_and_esm`
     ///
     /// WARNING: Snapshots MUST be used on the same system they were created on
     #[must_use]

--- a/src/snapshot_builder.rs
+++ b/src/snapshot_builder.rs
@@ -811,8 +811,7 @@ impl SnapshotBuilder {
     /// `include_bytes!`
     ///
     /// WARNING: In order to use the snapshot, make sure the runtime using it is
-    /// provided the same extensions and options as the original runtime. Any extensions
-    /// you provided must be loaded with `init_ops` instead of `init_ops_and_esm`.
+    /// provided the same extensions and options as the original runtime.
     #[must_use]
     pub fn finish(self) -> Box<[u8]> {
         let deno_rt: JsRuntimeForSnapshot = self.inner.into_inner();

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -632,7 +632,6 @@ pub struct DefaultWorkerOptions {
     /// Optional snapshot to load into the runtime
     /// This will reduce load times, but requires the same extensions to be loaded
     /// as when the snapshot was created
-    /// If provided, user-supplied extensions must be instantiated with `init_ops` instead of `init_ops_and_esm`
     pub startup_snapshot: Option<&'static [u8]>,
 
     /// Optional shared array buffer store to use for the runtime


### PR DESCRIPTION
The libffi dependency introduced (by way of deno_ffi) by #366 has caused master to break for me on macos; I decided to take a stab at a refactor to support 2.3.3 instead.