### PR TITLE
fix(web_stub): initialize `StartTime` state to fix `console.time()` crash

### DIFF
--- a/src/ext/web_stub/mod.rs
+++ b/src/ext/web_stub/mod.rs
@@ -8,6 +8,7 @@ use super::ExtensionTrait;
 
 mod encoding;
 mod timers;
+use timers::StartTime;
 
 extension!(
     deno_web,
@@ -17,6 +18,9 @@ extension!(
     ],
     esm_entry_point = "ext:deno_web/init_stub.js",
     esm = [ dir "src/ext/web_stub", "init_stub.js", "01_dom_exception.js", "02_timers.js", "05_base64.js" ],
+    state = |state| {
+        state.put(StartTime::default());
+    }
 );
 impl ExtensionTrait<()> for deno_web {
     fn init((): ()) -> Extension {

--- a/src/ext/web_stub/timers.rs
+++ b/src/ext/web_stub/timers.rs
@@ -5,7 +5,21 @@ use std::time::Instant;
 use deno_core::op2;
 use deno_core::OpState;
 
-pub type StartTime = Instant;
+pub struct StartTime(Instant);
+
+impl Default for StartTime {
+    fn default() -> Self {
+        Self(Instant::now())
+    }
+}
+
+impl std::ops::Deref for StartTime {
+    type Target = Instant;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 // Returns a milliseconds and nanoseconds subsec
 // since the start time of the deno runtime.


### PR DESCRIPTION
When executing javascript `console.time()` using the `web_stub` feature, we currently get a:
```
required type std::time::Instant is not present in GothamState container
```

This is because we never initialize the `StartTime` state used at:
https://github.com/rscarson/rustyscript/blob/8ef98fb1b9d83aa9c528a4a6c89905745bf43c39/src/ext/web_stub/timers.rs#L16

`op_now()` is called from deno_console at:
https://github.com/denoland/deno/blob/v2.4.5/ext/console/01_console.js#L169
(which is used in `console.time()`, `console.timeLog()`, and `console.timeEnd()`

I have a repro repo here:
https://github.com/SpiralP/rustyscript-console-time-bug

Noting I copied the `StartTime` struct style from upstream deno_web found here:
https://github.com/denoland/deno/blob/v2.4.5/ext/web/timers.rs#L24-L38