### PR TITLE
Give Promise, Runtime and Module Sync & Send Traits

### DIFF
--- a/src/js_value/promise.rs
+++ b/src/js_value/promise.rs
@@ -86,7 +86,13 @@ where
             }
         }
     }
+
+    // TODO: If Sync+Send Fails for runtime try defining Runtime as being binded to a preexisting mutex here.
 }
+
+unsafe impl <T: for <'de>Deserialize<'de>>Sync for Promise<T>{}
+unsafe impl <T: for <'de>Deserialize<'de>>Send for Promise<T>{}
+
 
 #[cfg(test)]
 mod test {

--- a/src/module.rs
+++ b/src/module.rs
@@ -250,6 +250,10 @@ impl Module {
     }
 }
 
+unsafe impl Send for Module {}
+unsafe impl Sync for Module {}
+
+
 #[cfg(test)]
 mod test_module {
     use super::*;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1148,6 +1148,11 @@ impl Runtime {
     }
 }
 
+
+unsafe impl Sync for Runtime {}
+unsafe impl Send for Runtime {}
+
+
 impl AsyncBridgeExt for Runtime {
     fn bridge(&self) -> &AsyncBridge {
         &self.tokio


### PR DESCRIPTION
I was having trouble binding rustyscript to pyo3 without Sync & Send traits and using a mutex to do it felt super annoying so I have implemented a few here in order to make things less annoying or stressful.